### PR TITLE
Fix html editor style preservation

### DIFF
--- a/GestorCompras_/gestorcompras/gui/config_gui.py
+++ b/GestorCompras_/gestorcompras/gui/config_gui.py
@@ -362,6 +362,7 @@ class TemplateForm(tk.Toplevel):
         # Recreate missing tables if the database was not initialized
         db.init_db()
         name = self.name_var.get().strip()
+        self.editor.text.tag_remove("sel", "1.0", "end")
         raw_text = self.editor.text.get("1.0", "end-1c").strip()
         html = self.editor.get_html().strip()
         if not html and raw_text:

--- a/GestorCompras_/gestorcompras/gui/config_gui.py
+++ b/GestorCompras_/gestorcompras/gui/config_gui.py
@@ -36,6 +36,16 @@ class ConfigGUI(tk.Toplevel):
         self.create_email_templates_tab()
     
     def create_suppliers_tab(self):
+        search_frame = ttk.Frame(self.suppliers_frame, style="MyFrame.TFrame")
+        search_frame.pack(fill="x", pady=(0,5))
+        ttk.Label(search_frame, text="Buscar:", style="MyLabel.TLabel").pack(side="left")
+        self.search_var = tk.StringVar()
+        search_entry = ttk.Entry(search_frame, textvariable=self.search_var, style="MyEntry.TEntry")
+        search_entry.pack(side="left", fill="x", expand=True, padx=5)
+        self.search_var.trace_add("write", lambda *args: self.filter_suppliers())
+        ttk.Button(search_frame, text="Limpiar", style="MyButton.TButton", command=lambda: self.search_var.set(""))\
+            .pack(side="left", padx=5)
+
         # Contenedor para el Treeview y sus scrollbars
         container = ttk.Frame(self.suppliers_frame, style="MyFrame.TFrame")
         container.pack(fill="both", expand=True)
@@ -81,11 +91,18 @@ class ConfigGUI(tk.Toplevel):
                    command=self.delete_supplier).pack(side="left", padx=5)
     
     def load_suppliers(self):
-        for i in self.suppliers_list.get_children():
-            self.suppliers_list.delete(i)
-        for sup in db.get_suppliers():
+        term = getattr(self, "search_var", None)
+        if term and term.get().strip():
+            suppliers = db.search_suppliers(term.get().strip())
+        else:
+            suppliers = db.get_suppliers()
+        self.suppliers_list.delete(*self.suppliers_list.get_children())
+        for sup in suppliers:
             self.suppliers_list.insert("", "end", values=sup)
         self.auto_adjust_columns()
+
+    def filter_suppliers(self):
+        self.load_suppliers()
     
     def auto_adjust_columns(self):
         style = ttk.Style()

--- a/GestorCompras_/gestorcompras/gui/html_editor.py
+++ b/GestorCompras_/gestorcompras/gui/html_editor.py
@@ -146,8 +146,10 @@ class HtmlEditor(ttk.Frame):
         open_tags = []
         for _index, kind, value in dump:
             if kind == "tagon":
-                html_chunks.append(self._tag_start_html(value))
-                open_tags.append(value)
+                html_start = self._tag_start_html(value)
+                if html_start:
+                    html_chunks.append(html_start)
+                    open_tags.append(value)
             elif kind == "tagoff":
                 if value in open_tags:
                     temp = []

--- a/GestorCompras_/gestorcompras/gui/html_editor.py
+++ b/GestorCompras_/gestorcompras/gui/html_editor.py
@@ -141,7 +141,16 @@ class HtmlEditor(ttk.Frame):
 
     # ---------- HTML Import/Export ----------
     def get_html(self):
-        """Export the current text content as HTML."""
+        """Return the current text as sanitized HTML.
+
+        The Text widget exposes formatting through tags.  To reliably
+        convert the content we walk each character and compare the tags
+        present at that index against the tags from the previous
+        character.  Closing tags are emitted for styles that end and new
+        tags are opened in a deterministic order before writing the
+        actual character.  This ensures that nested styling is exported
+        with valid markup and that unrecognised tags are ignored.
+        """
         end_index = self.text.index("end-1c")
         index = "1.0"
         prev_tags = []

--- a/GestorCompras_/gestorcompras/gui/html_editor.py
+++ b/GestorCompras_/gestorcompras/gui/html_editor.py
@@ -143,13 +143,28 @@ class HtmlEditor(ttk.Frame):
     def get_html(self):
         dump = self.text.dump("1.0", "end-1c", tag=True, text=True)
         html_chunks = []
-        for index, kind, value in dump:
+        open_tags = []
+        for _index, kind, value in dump:
             if kind == "tagon":
                 html_chunks.append(self._tag_start_html(value))
+                open_tags.append(value)
             elif kind == "tagoff":
-                html_chunks.append(self._tag_end_html(value))
+                if value in open_tags:
+                    temp = []
+                    while open_tags:
+                        current = open_tags.pop()
+                        html_chunks.append(self._tag_end_html(current))
+                        if current == value:
+                            break
+                        temp.append(current)
+                    while temp:
+                        t = temp.pop()
+                        html_chunks.append(self._tag_start_html(t))
+                        open_tags.append(t)
             elif kind == "text":
                 html_chunks.append(escape(value).replace("\n", "<br>"))
+        while open_tags:
+            html_chunks.append(self._tag_end_html(open_tags.pop()))
         return "".join(html_chunks)
 
     def set_html(self, html_string):

--- a/GestorCompras_/gestorcompras/gui/html_editor.py
+++ b/GestorCompras_/gestorcompras/gui/html_editor.py
@@ -100,7 +100,7 @@ class HtmlEditor(ttk.Frame):
 
     def _apply_font(self):
         family = self.font_var.get()
-        tag = f"font_{family}"
+        tag = f"font_{family.replace(' ', '_')}"
         try:
             start = self.text.index("sel.first")
             end = self.text.index("sel.last")
@@ -128,7 +128,7 @@ class HtmlEditor(ttk.Frame):
         color = colorchooser.askcolor()[1]
         if not color:
             return
-        tag = f"color_{color}"
+        tag = f"color_{color.lstrip('#')}"
         try:
             start = self.text.index("sel.first")
             end = self.text.index("sel.last")
@@ -181,17 +181,20 @@ class HtmlEditor(ttk.Frame):
                     for part in style.split(";"):
                         if "font-family" in part:
                             family = part.split(":")[1].strip()
-                            tag_name = f"font_{family}"
+                            tag_name = f"font_{family.replace(' ', '_')}"
+                            self.widget.tag_configure(tag_name, font=tkfont.Font(family=family))
                             self.tag_stack.append(tag_name)
                             tags.append(tag_name)
                         elif "font-size" in part:
                             size = part.split(":")[1].strip().rstrip("px").rstrip("pt")
                             tag_name = f"size_{size}"
+                            self.widget.tag_configure(tag_name, font=tkfont.Font(size=int(size)))
                             self.tag_stack.append(tag_name)
                             tags.append(tag_name)
                         elif "color" in part:
                             color = part.split(":")[1].strip()
-                            tag_name = f"color_{color}"
+                            tag_name = f"color_{color.lstrip('#')}"
+                            self.widget.tag_configure(tag_name, foreground=color)
                             self.tag_stack.append(tag_name)
                             tags.append(tag_name)
                     self.span_stack.append(tags)
@@ -233,13 +236,15 @@ class HtmlEditor(ttk.Frame):
         if tag == "underline":
             return "<u>"
         if tag.startswith("font_"):
-            family = tag.split("_", 1)[1]
+            family = tag.split("_", 1)[1].replace("_", " ")
             return f'<span style="font-family:{family}">'
         if tag.startswith("size_"):
             size = tag.split("_", 1)[1]
             return f'<span style="font-size:{size}px">'
         if tag.startswith("color_"):
             color = tag.split("_", 1)[1]
+            if not color.startswith("#"):
+                color = "#" + color
             return f'<span style="color:{color}">'
         return ""
 

--- a/GestorCompras_/gestorcompras/services/db.py
+++ b/GestorCompras_/gestorcompras/services/db.py
@@ -244,6 +244,19 @@ def get_email_templates():
     conn.close()
     return rows
 
+def search_suppliers(term):
+    """Busca proveedores por coincidencia parcial en nombre o RUC."""
+    conn = get_connection()
+    cursor = conn.cursor()
+    like = f"%{term}%"
+    cursor.execute(
+        "SELECT id, name, ruc, email, COALESCE(email_alt, '') FROM suppliers WHERE name LIKE ? OR ruc LIKE ?",
+        (like, like),
+    )
+    rows = cursor.fetchall()
+    conn.close()
+    return rows
+
 def get_email_template(template_id):
     conn = get_connection()
     cursor = conn.cursor()


### PR DESCRIPTION
## Summary
- preserve font and color styling when loading email templates
- sanitize font family names in tag identifiers
- ensure color tags work without `#` in tag name

## Testing
- `python3 -m py_compile GestorCompras_/gestorcompras/gui/html_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_685cddfb480883208f8202104f460e10