### PR TITLE
Extract SMTP configuration to env

### DIFF
--- a/GestorCompras_/gestorcompras/services/db.py
+++ b/GestorCompras_/gestorcompras/services/db.py
@@ -244,6 +244,19 @@ def get_email_templates():
     conn.close()
     return rows
 
+def search_suppliers(query):
+    """Devuelve proveedores cuyo nombre o RUC coincidan parcialmente"""
+    like = f"%{query}%"
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT id, name, ruc, email, COALESCE(email_alt, '') FROM suppliers WHERE name LIKE ? OR ruc LIKE ?",
+        (like, like),
+    )
+    rows = cursor.fetchall()
+    conn.close()
+    return rows
+
 def get_email_template(template_id):
     conn = get_connection()
     cursor = conn.cursor()

--- a/GestorCompras_/gestorcompras/services/email_sender.py
+++ b/GestorCompras_/gestorcompras/services/email_sender.py
@@ -4,13 +4,21 @@ import base64
 import re
 from email.message import EmailMessage
 from jinja2 import Environment, FileSystemLoader
+from gestorcompras.services import db
 
 # Configuración de la ruta donde se ubicarán las plantillas
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
 env = Environment(loader=FileSystemLoader(TEMPLATE_DIR), autoescape=True)
 
-SMTP_SERVER = "smtp.telconet.ec"
-SMTP_PORT = 587
+SMTP_SERVER = os.getenv(
+    "SMTP_SERVER", db.get_config("SMTP_SERVER", "smtp.telconet.ec")
+)
+SMTP_PORT = int(
+    os.getenv("SMTP_PORT", db.get_config("SMTP_PORT", "587"))
+)
+EMAIL_CC = os.getenv(
+    "EMAIL_CC", db.get_config("EMAIL_CC", "jotoapanta@telconet.ec")
+)
 
 def render_email(template_name, context):
     """
@@ -34,7 +42,8 @@ def send_email(email_session, subject, template_text, template_html, context, at
     msg["Subject"] = subject.upper()
     msg["From"] = email_session["address"]
     msg["To"] = context.get("email_to", "")
-    msg["Cc"] = "jotoapanta@telconet.ec"
+    if EMAIL_CC:
+        msg["Cc"] = EMAIL_CC
     # Renderizamos el contenido
     content_text = render_email(template_text, context)
     content_html = render_email(template_html, context)
@@ -86,7 +95,8 @@ def send_email_custom(email_session, subject, html_template, context, attachment
     msg["Subject"] = subject.upper()
     msg["From"] = email_session["address"]
     msg["To"] = context.get("email_to", "")
-    msg["Cc"] = "jotoapanta@telconet.ec"
+    if EMAIL_CC:
+        msg["Cc"] = EMAIL_CC
 
     msg.set_content(content_text)
     msg.add_alternative(content_html, subtype="html")

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ GestorCompras - Versión Preliminar
  Características Principales
  ----------------------------
 - Gestión de Proveedores: Registro, edición y eliminación de proveedores.
+- Búsqueda rápida por RUC o nombre para ubicar proveedores existentes.
 - Cada proveedor puede tener un correo de respaldo para notificaciones.
  - Configuración de Asignaciones: Asignación única de personas a departamentos.
  - Gestión de Tareas Temporales: Carga, procesamiento y eliminación de tareas notificadas por correo.
-- Automatización de Despachos: Envío automatizado de solicitudes de despacho mediante correo electrónico, con plantillas configurables.
+- Automatización de Despachos: Envío automatizado de solicitudes de despacho mediante correo electrónico, con plantillas configurables y confirmación previa de los correos a enviar.
 - Formatos de Correo Personalizados: desde la configuración es posible crear, editar y eliminar plantillas en HTML, ahora con un editor visual que permite aplicar negritas, colores, tamaños de letra y viñetas, además de incluir una imagen de firma.
  - Interfaz Gráfica Profesional: Desarrollada en Tkinter, ofreciendo una experiencia intuitiva y ordenada.
  - Integración con Base de Datos SQLite: Manejo local de datos a través de una base de datos autogenerada.
@@ -35,10 +36,12 @@ GestorCompras - Versión Preliminar
       (Asegúrese de tener instaladas todas las librerías necesarias según su entorno de desarrollo.)
    3. Configuración de la Base de Datos:
       La base de datos SQLite se inicializa automáticamente al ejecutar la aplicación. Los datos se almacenan en el directorio "data".
-   4. Carga rápida de Proveedores:
+   4. Configuración de SMTP (opcional):
+      Puede definir las variables de entorno `SMTP_SERVER`, `SMTP_PORT` y `EMAIL_CC` para personalizar el servidor de correo y la dirección de copia.
+   5. Carga rápida de Proveedores:
       Se incluye el script "import_proveedores.py" que permite agregar de forma rápida proveedores a la base de datos a partir de un archivo Excel (correos.xlsx). Para ejecutarlo, desde el directorio del proyecto, ejecute:
         python import_proveedores.py
-   5. Ejecutar la Aplicación:
+   6. Ejecutar la Aplicación:
         python main.py
  
  Uso


### PR DESCRIPTION
## Summary
- configure SMTP constants from env or DB
- allow optional EMAIL_CC
- document new SMTP environment variables
- add quick supplier search and maintain results while editing
- confirm dispatch emails before sending and report success or failure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ef2b502908320a9326ee4f86049a4