### PR TITLE
Add pytest and unit tests

### DIFF
--- a/GestorCompras_/tests/test_db.py
+++ b/GestorCompras_/tests/test_db.py
@@ -1,0 +1,25 @@
+import os
+import tempfile
+
+import pytest
+
+from gestorcompras.services import db
+
+
+def setup_temp_db(monkeypatch):
+    tmp_dir = tempfile.TemporaryDirectory()
+    db_path = os.path.join(tmp_dir.name, 'test.db')
+    monkeypatch.setattr(db, 'DB_PATH', db_path, raising=False)
+    monkeypatch.setattr(db, 'DB_DIR', tmp_dir.name, raising=False)
+    db.init_db()
+    return tmp_dir
+
+
+def test_get_suppliers_returns_inserted_suppliers(monkeypatch):
+    tmp = setup_temp_db(monkeypatch)
+    try:
+        db.add_supplier('Prov', '123', 'a@b.com', 'c@d.com')
+        suppliers = db.get_suppliers()
+        assert suppliers == [(1, 'Prov', '123', 'a@b.com', 'c@d.com')]
+    finally:
+        tmp.cleanup()

--- a/GestorCompras_/tests/test_despacho_logic.py
+++ b/GestorCompras_/tests/test_despacho_logic.py
@@ -1,0 +1,17 @@
+from gestorcompras.logic import despacho_logic
+from gestorcompras.services import db
+
+
+def test_obtener_resumen_orden(monkeypatch):
+    # patch funciones que buscan pdf y extraen info
+    monkeypatch.setattr(despacho_logic, 'buscar_archivo_mas_reciente', lambda o: ('/tmp/file.pdf', 'FOO'))
+    monkeypatch.setattr(despacho_logic, 'extraer_info_de_pdf', lambda p: ('123', '555'))
+    monkeypatch.setattr(despacho_logic, 'get_suppliers', lambda: [(1, 'Prov', '123', 'a@b.com', 'b@b.com')])
+
+    info, error = despacho_logic.obtener_resumen_orden('OC1')
+    assert error is None
+    assert info['orden'] == 'OC1'
+    assert info['tarea'] == '555'
+    assert info['folder_name'] == 'FOO'
+    assert info['emails'] == ['a@b.com', 'b@b.com']
+    assert info['pdf_path'] == '/tmp/file.pdf'

--- a/GestorCompras_/tests/test_email_rendering.py
+++ b/GestorCompras_/tests/test_email_rendering.py
@@ -1,0 +1,7 @@
+from gestorcompras.services import email_sender
+
+
+def test_render_email_string_renders_template():
+    template = "Hola {{ name }}"
+    result = email_sender.render_email_string(template, {"name": "Mundo"})
+    assert "Hola Mundo" == result

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ GestorCompras - Versión Preliminar
    2. Instalar las dependencias:
         pip install -r requirements.txt
       (Asegúrese de tener instaladas todas las librerías necesarias según su entorno de desarrollo.)
+      Para ejecutar las pruebas unitarias, instale además:
+        pip install -r requirements-dev.txt
    3. Configuración de la Base de Datos:
       La base de datos SQLite se inicializa automáticamente al ejecutar la aplicación. Los datos se almacenan en el directorio "data".
    4. Carga rápida de Proveedores:
@@ -40,14 +42,21 @@ GestorCompras - Versión Preliminar
         python import_proveedores.py
    5. Ejecutar la Aplicación:
         python main.py
- 
- Uso
- ---
+
+Uso
+---
  Al iniciar la aplicación se presenta una pantalla de inicio de sesión. Una vez autenticado, el usuario accede a un menú principal que permite:
    - Administrar proveedores.
    - Configurar asignaciones de departamentos.
    - Cargar y gestionar tareas temporales notificadas por correo.
    - Enviar solicitudes de despacho a través de correos electrónicos predefinidos.
+
+Pruebas
+-------
+Con las dependencias de desarrollo instaladas, ejecute las pruebas con:
+```
+pytest
+```
  
  Aclaraciones y Disclaimer Legal
  ---------------------------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt` with pytest
- document how to run tests in README
- test `db.get_suppliers`
- test `despacho_logic.obtener_resumen_orden`
- test email template rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f019335b883208f356561e1c13039