### PR TITLE
Make CC email configurable

### DIFF
--- a/GestorCompras_/gestorcompras/services/email_sender.py
+++ b/GestorCompras_/gestorcompras/services/email_sender.py
@@ -5,12 +5,23 @@ import re
 from email.message import EmailMessage
 from jinja2 import Environment, FileSystemLoader
 
+from . import db
+
 # Configuración de la ruta donde se ubicarán las plantillas
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
 env = Environment(loader=FileSystemLoader(TEMPLATE_DIR), autoescape=True)
 
 SMTP_SERVER = "smtp.telconet.ec"
 SMTP_PORT = 587
+
+DEFAULT_CC = "jotoapanta@telconet.ec"
+
+def get_cc_address():
+    """Obtiene la dirección de correo en copia (CC)."""
+    env_cc = os.getenv("EMAIL_CC")
+    if env_cc:
+        return env_cc
+    return db.get_config("EMAIL_CC", DEFAULT_CC)
 
 def render_email(template_name, context):
     """
@@ -34,7 +45,7 @@ def send_email(email_session, subject, template_text, template_html, context, at
     msg["Subject"] = subject.upper()
     msg["From"] = email_session["address"]
     msg["To"] = context.get("email_to", "")
-    msg["Cc"] = "jotoapanta@telconet.ec"
+    msg["Cc"] = get_cc_address()
     # Renderizamos el contenido
     content_text = render_email(template_text, context)
     content_html = render_email(template_html, context)
@@ -86,7 +97,7 @@ def send_email_custom(email_session, subject, html_template, context, attachment
     msg["Subject"] = subject.upper()
     msg["From"] = email_session["address"]
     msg["To"] = context.get("email_to", "")
-    msg["Cc"] = "jotoapanta@telconet.ec"
+    msg["Cc"] = get_cc_address()
 
     msg.set_content(content_text)
     msg.add_alternative(content_html, subtype="html")

--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ GestorCompras - Versión Preliminar
       (Asegúrese de tener instaladas todas las librerías necesarias según su entorno de desarrollo.)
       Para ejecutar las pruebas unitarias, instale además:
         pip install -r requirements-dev.txt
-   3. Configuración de la Base de Datos:
-      La base de datos SQLite se inicializa automáticamente al ejecutar la aplicación. Los datos se almacenan en el directorio "data".
-   4. Carga rápida de Proveedores:
-      Se incluye el script "import_proveedores.py" que permite agregar de forma rápida proveedores a la base de datos a partir de un archivo Excel (correos.xlsx). Para ejecutarlo, desde el directorio del proyecto, ejecute:
-        python import_proveedores.py
-   5. Ejecutar la Aplicación:
-        python main.py
+  3. Configuración de la Base de Datos:
+     La base de datos SQLite se inicializa automáticamente al ejecutar la aplicación. Los datos se almacenan en el directorio "data".
+  4. Configurar dirección en copia (CC) *(opcional)*:
+     Defina la dirección que recibirá copia de los correos estableciendo la variable de entorno `EMAIL_CC` o guardando la clave `EMAIL_CC` en la base de datos. Si no se especifica, se utilizará `jotoapanta@telconet.ec`.
+  5. Carga rápida de Proveedores:
+     Se incluye el script "import_proveedores.py" que permite agregar de forma rápida proveedores a la base de datos a partir de un archivo Excel (correos.xlsx). Para ejecutarlo, desde el directorio del proyecto, ejecute:
+       python import_proveedores.py
+  6. Ejecutar la Aplicación:
+       python main.py
 
 Uso
 ---


### PR DESCRIPTION
## Summary
- make CC address configurable via environment variable or stored config
- document how to set the CC email

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862ce784af48320ab51b445af23f2ae