### PR TITLE
Add Google Sheets integration

### DIFF
--- a/GestorCompras_/gestorcompras/gui/config_gui.py
+++ b/GestorCompras_/gestorcompras/gui/config_gui.py
@@ -213,6 +213,19 @@ class ConfigGUI(tk.Toplevel):
                                    style="MyEntry.TEntry", width=50)
         self.pdf_entry.pack(pady=5)
 
+        ttk.Label(frame, text="Credenciales Google (JSON):",
+                  style="MyLabel.TLabel").pack(pady=5)
+
+        self.google_creds_var = tk.StringVar()
+        self.google_creds_var.set(db.get_config("GOOGLE_CREDS", ""))
+
+        ttk.Entry(frame, textvariable=self.google_creds_var,
+                  style="MyEntry.TEntry", width=50).pack(pady=5)
+
+        ttk.Button(frame, text="Seleccionar Credenciales",
+                   style="MyButton.TButton",
+                   command=self.select_google_creds).pack(pady=5)
+
         ttk.Label(frame, text="Correos CC (hasta 9, separados por ';'):",
                   style="MyLabel.TLabel").pack(pady=5)
 
@@ -234,6 +247,11 @@ class ConfigGUI(tk.Toplevel):
         folder_selected = filedialog.askdirectory(title="Seleccionar carpeta para PDFs")
         if folder_selected:
             self.pdf_path_var.set(folder_selected)
+
+    def select_google_creds(self):
+        path = filedialog.askopenfilename(title="Seleccionar archivo de credenciales", filetypes=[("JSON", "*.json")])
+        if path:
+            self.google_creds_var.set(path)
     
     def save_general_config(self):
         pdf_folder = self.pdf_path_var.get().strip()
@@ -251,6 +269,7 @@ class ConfigGUI(tk.Toplevel):
 
         db.set_config("PDF_FOLDER", pdf_folder)
         db.set_config("EMAIL_CC", ";".join(emails) if emails else "")
+        db.set_config("GOOGLE_CREDS", self.google_creds_var.get().strip())
         messagebox.showinfo(
             "Información", "Configuración guardada correctamente.")
     

--- a/GestorCompras_/gestorcompras/gui/google_sheet_gui.py
+++ b/GestorCompras_/gestorcompras/gui/google_sheet_gui.py
@@ -1,0 +1,94 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+from tkinter.scrolledtext import ScrolledText
+
+from gestorcompras.services import db
+from gestorcompras.services import google_sheets
+from gestorcompras.logic import despacho_logic
+
+
+def open_sheet_report(master, email_session):
+    window = tk.Toplevel(master)
+    window.title("Reporte Google Sheets")
+    window.geometry("700x500")
+    window.transient(master)
+    window.grab_set()
+
+    frame = ttk.Frame(window, padding=10, style="MyFrame.TFrame")
+    frame.pack(fill="both", expand=True)
+    frame.columnconfigure(0, weight=1)
+    frame.rowconfigure(4, weight=1)
+
+    ttk.Label(frame, text="Spreadsheet ID:", style="MyLabel.TLabel").grid(row=0, column=0, sticky="w")
+    sheet_id_var = tk.StringVar()
+    ttk.Entry(frame, textvariable=sheet_id_var, style="MyEntry.TEntry").grid(row=1, column=0, sticky="ew", pady=5)
+
+    ttk.Label(frame, text="Nombre de la Hoja:", style="MyLabel.TLabel").grid(row=2, column=0, sticky="w")
+    sheet_name_var = tk.StringVar()
+    ttk.Entry(frame, textvariable=sheet_name_var, style="MyEntry.TEntry").grid(row=3, column=0, sticky="ew", pady=5)
+
+    tree = ttk.Treeview(frame, columns=("tarea", "oc", "proveedor"), show="headings", style="MyTreeview.Treeview")
+    tree.heading("tarea", text="Tarea")
+    tree.heading("oc", text="Orden")
+    tree.heading("proveedor", text="Proveedor")
+    tree.grid(row=4, column=0, sticky="nsew", pady=5)
+
+    log_box = ScrolledText(frame, height=6, state="disabled")
+    log_box.grid(row=6, column=0, sticky="nsew", pady=5)
+
+    ttk.Label(frame, text="Formato de correo:", style="MyLabel.TLabel").grid(row=5, column=0, sticky="w")
+    formatos = ["Bienes", "Servicios"] + [tpl[1] for tpl in db.get_email_templates()]
+    formato_var = tk.StringVar(value=db.get_config("EMAIL_TEMPLATE", "Bienes"))
+    ttk.Combobox(frame, textvariable=formato_var, values=formatos, state="readonly").grid(row=5, column=0, sticky="e", padx=(150,0))
+
+    attach_var = tk.BooleanVar(value=True)
+    ttk.Checkbutton(frame, text="Adjuntar PDF", variable=attach_var, style="MyCheckbutton.TCheckbutton").grid(row=7, column=0, sticky="w")
+
+    def log(msg: str):
+        log_box.configure(state="normal")
+        log_box.insert(tk.END, msg + "\n")
+        log_box.see(tk.END)
+        log_box.configure(state="disabled")
+
+    def load_report():
+        creds = db.get_config("GOOGLE_CREDS", "")
+        sid = sheet_id_var.get().strip()
+        sname = sheet_name_var.get().strip()
+        if not (creds and sid and sname):
+            messagebox.showwarning("Advertencia", "Debe completar Spreadsheet ID y nombre de hoja y configurar las credenciales.")
+            return
+        try:
+            rows = google_sheets.read_report(creds, sid, sname)
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+            return
+        for i in tree.get_children():
+            tree.delete(i)
+        for r in rows:
+            tree.insert("", "end", values=(r["Tarea"], r["Orden de Compra"], r["Proveedor"]))
+        messagebox.showinfo("Información", f"Se cargaron {len(rows)} registros")
+
+    def send_emails():
+        items = tree.get_children()
+        if not items:
+            messagebox.showwarning("Advertencia", "No hay datos para enviar")
+            return
+        if not messagebox.askyesno("Confirmar", f"¿Enviar {len(items)} correos?"):
+            return
+        for it in items:
+            tarea, oc, prov = tree.item(it)["values"]
+            result = despacho_logic.process_order(
+                email_session,
+                str(oc),
+                include_pdf=attach_var.get(),
+                template_name=formato_var.get(),
+            )
+            log(result)
+        messagebox.showinfo("Finalizado", "Proceso completado")
+
+    btn_frame = ttk.Frame(frame, style="MyFrame.TFrame")
+    btn_frame.grid(row=8, column=0, pady=10)
+    ttk.Button(btn_frame, text="Cargar Reporte", style="MyButton.TButton", command=load_report).pack(side="left", padx=5)
+    ttk.Button(btn_frame, text="Enviar Correos", style="MyButton.TButton", command=send_emails).pack(side="left", padx=5)
+
+

--- a/GestorCompras_/gestorcompras/logic/despacho_logic.py
+++ b/GestorCompras_/gestorcompras/logic/despacho_logic.py
@@ -81,7 +81,7 @@ def obtener_resumen_orden(orden):
         "pdf_path": pdf_path,
     }, None
 
-def process_order(email_session, orden):
+def process_order(email_session, orden, include_pdf=True, template_name=None):
     info, error = obtener_resumen_orden(orden)
     if not info:
         return f"⚠ {error}"
@@ -98,7 +98,7 @@ def process_order(email_session, orden):
     }
     
     # Seleccionar formato de correo según la configuración
-    formato = get_config("EMAIL_TEMPLATE", "Bienes")
+    formato = template_name or get_config("EMAIL_TEMPLATE", "Bienes")
     template_db = get_email_template_by_name(formato)
     html_content = None
     signature_path = None
@@ -126,7 +126,7 @@ def process_order(email_session, orden):
                 subject,
                 html_content,
                 context,
-                attachment_path=pdf_path,
+                attachment_path=pdf_path if include_pdf else None,
                 signature_path=signature_path,
             )
         else:
@@ -136,7 +136,7 @@ def process_order(email_session, orden):
                 template_text,
                 template_html,
                 context,
-                attachment_path=pdf_path,
+                attachment_path=pdf_path if include_pdf else None,
             )
         return f"✅ Correo enviado a {context['email_to']} con la OC {orden}" + (f" (Tarea: {tarea})" if tarea else "")
     except Exception as e:

--- a/GestorCompras_/gestorcompras/main.py
+++ b/GestorCompras_/gestorcompras/main.py
@@ -5,6 +5,7 @@ from gestorcompras.services import db
 from gestorcompras.gui import config_gui
 from gestorcompras.gui import reasignacion_gui
 from gestorcompras.gui import despacho_gui
+from gestorcompras.gui import google_sheet_gui
 
 # Palette
 bg_base = "#F0F4F8"
@@ -159,6 +160,7 @@ class MainMenu(tk.Frame):
         buttons = [
             ("Reasignación de Tareas", self.open_reasignacion),
             ("Solicitud de Despachos", self.open_despacho),
+            ("Despachos desde Sheet", self.open_sheet_report),
             ("Cotizador", self.open_cotizador),
             ("Configuración", self.open_config),
             ("Salir", self.master.quit)
@@ -172,6 +174,9 @@ class MainMenu(tk.Frame):
     
     def open_despacho(self):
         despacho_gui.open_despacho(self.master, email_session)
+
+    def open_sheet_report(self):
+        google_sheet_gui.open_sheet_report(self.master, email_session)
     
     def open_config(self):
         config_gui.open_config_gui(self.master)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pandas
 openpyxl
 selenium 
 webdriver_manager
+gspread
+google-auth


### PR DESCRIPTION
## Summary
- add gspread/google-auth dependencies
- implement `google_sheets` service to read reports from Google Sheets
- allow configuring credentials path in Config GUI
- add new GUI window to load sheet reports and send emails
- extend main menu for the new option
- update `process_order` to allow custom template and optional attachments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640582186c8320b76ae4d8a61d451a