### PR TITLE
Add tracking/dispatch config and CC options

### DIFF
--- a/GestorCompras_/gestorcompras/gui/despacho_gui.py
+++ b/GestorCompras_/gestorcompras/gui/despacho_gui.py
@@ -4,6 +4,7 @@ from tkinter.scrolledtext import ScrolledText
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from gestorcompras.logic import despacho_logic
+from gestorcompras.services import db
 
 def open_despacho(master, email_session):
     window = tk.Toplevel(master)
@@ -15,7 +16,7 @@ def open_despacho(master, email_session):
     main_frame = ttk.Frame(window, style="MyFrame.TFrame", padding=10)
     main_frame.pack(fill="both", expand=True)
     main_frame.rowconfigure(1, weight=1)
-    main_frame.rowconfigure(2, weight=1)
+    main_frame.rowconfigure(3, weight=1)
     main_frame.columnconfigure(0, weight=1)
     
     label = ttk.Label(main_frame, text="Ingrese números de OC (una por línea):", style="MyLabel.TLabel")
@@ -24,8 +25,14 @@ def open_despacho(master, email_session):
     text_area = tk.Text(main_frame, height=10)
     text_area.grid(row=1, column=0, sticky="nsew", padx=5, pady=5)
     
+    ttk.Label(main_frame, text="Estado del Proceso:", style="MyLabel.TLabel").grid(row=2, column=0, sticky="w")
     log_box = ScrolledText(main_frame, height=8, state="disabled")
-    log_box.grid(row=2, column=0, sticky="nsew", padx=5, pady=5)
+    log_box.grid(row=3, column=0, sticky="nsew", padx=5, pady=5)
+
+    ttk.Label(main_frame, text="Formato de correo:", style="MyLabel.TLabel").grid(row=4, column=0, sticky="w")
+    formatos = ["Bienes", "Servicios"] + [tpl[1] for tpl in db.get_email_templates()]
+    formato_var = tk.StringVar(value=db.get_config("EMAIL_TEMPLATE", "Bienes"))
+    ttk.Combobox(main_frame, textvariable=formato_var, values=formatos, state="readonly").grid(row=4, column=0, sticky="e", padx=(150,0))
     
     def log_func(message):
         log_box.configure(state="normal")
@@ -58,7 +65,17 @@ def open_despacho(master, email_session):
         def process_all_orders():
             results = []
             with ThreadPoolExecutor(max_workers=4) as executor:
-                futures = [executor.submit(despacho_logic.process_order, email_session, orden) for orden in orders]
+                futures = [
+                    executor.submit(
+                        despacho_logic.process_order,
+                        email_session,
+                        orden,
+                        True,
+                        formato_var.get(),
+                        "EMAIL_CC_DESPACHO",
+                    )
+                    for orden in orders
+                ]
                 for future in as_completed(futures):
                     try:
                         result = future.result()
@@ -70,8 +87,8 @@ def open_despacho(master, email_session):
             window.after(0, lambda: btn_procesar.configure(state="normal"))
 
         threading.Thread(target=process_all_orders).start()
-    
+
     btn_procesar = ttk.Button(main_frame, text="Procesar Despachos",
                                style="MyButton.TButton",
                                command=process_input_orders)
-    btn_procesar.grid(row=3, column=0, pady=10)
+    btn_procesar.grid(row=5, column=0, pady=10)

--- a/GestorCompras_/gestorcompras/gui/seguimientos_gui.py
+++ b/GestorCompras_/gestorcompras/gui/seguimientos_gui.py
@@ -44,6 +44,7 @@ def open_seguimientos(master, email_session):
     canvas.pack(side="left", fill="both", expand=True)
     scrollbar.pack(side="right", fill="y")
 
+    ttk.Label(frame, text="Estado del Proceso:", style="MyLabel.TLabel").grid(row=5, column=0, sticky="w")
     log_box = ScrolledText(frame, height=6, state="disabled")
     log_box.grid(row=6, column=0, sticky="nsew", pady=5)
 
@@ -106,6 +107,8 @@ def open_seguimientos(master, email_session):
                 str(r["Orden de Compra"]),
                 include_pdf=attach_var.get(),
                 template_name=formato_var.get(),
+                cc_key="EMAIL_CC_SEGUIMIENTO",
+                provider_name=r.get("Proveedor"),
             )
             log(result)
         messagebox.showinfo("Finalizado", "Proceso completado")

--- a/GestorCompras_/gestorcompras/services/db.py
+++ b/GestorCompras_/gestorcompras/services/db.py
@@ -286,6 +286,18 @@ def search_suppliers(term):
     conn.close()
     return rows
 
+def get_supplier_by_name(name: str):
+    """Retorna la información de un proveedor buscándolo por nombre exacto."""
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT id, name, ruc, email, COALESCE(email_alt, '') FROM suppliers WHERE UPPER(name)=UPPER(?)",
+        (name,),
+    )
+    row = cursor.fetchone()
+    conn.close()
+    return row
+
 def get_email_template(template_id):
     conn = get_connection()
     cursor = conn.cursor()

--- a/GestorCompras_/gestorcompras/services/email_sender.py
+++ b/GestorCompras_/gestorcompras/services/email_sender.py
@@ -14,12 +14,12 @@ env = Environment(loader=FileSystemLoader(TEMPLATE_DIR), autoescape=True)
 SMTP_SERVER = "smtp.telconet.ec"
 SMTP_PORT = 587
 
-def get_cc_address():
-    """Obtiene la dirección de correo en copia (CC)."""
-    env_cc = os.getenv("EMAIL_CC")
+def get_cc_address(key="EMAIL_CC_DESPACHO"):
+    """Obtiene la dirección de correo en copia (CC) para la clave dada."""
+    env_cc = os.getenv(key)
     if env_cc:
         return env_cc
-    return db.get_config("EMAIL_CC", "")
+    return db.get_config(key, "")
 
 def render_email(template_name, context):
     """
@@ -28,7 +28,7 @@ def render_email(template_name, context):
     template = env.get_template(template_name)
     return template.render(context)
 
-def send_email(email_session, subject, template_text, template_html, context, attachment_path=None):
+def send_email(email_session, subject, template_text, template_html, context, attachment_path=None, cc_key="EMAIL_CC_DESPACHO"):
     """
     Envía un correo utilizando SMTP.
     
@@ -43,7 +43,7 @@ def send_email(email_session, subject, template_text, template_html, context, at
     msg["Subject"] = subject.upper()
     msg["From"] = email_session["address"]
     msg["To"] = context.get("email_to", "")
-    cc = get_cc_address()
+    cc = get_cc_address(cc_key)
     if cc:
         msg["Cc"] = cc
     # Renderizamos el contenido
@@ -84,7 +84,7 @@ def image_to_data_uri(path):
     ext = os.path.splitext(path)[1].lower().strip(".") or "png"
     return f"data:image/{ext};base64,{data}"
 
-def send_email_custom(email_session, subject, html_template, context, attachment_path=None, signature_path=None):
+def send_email_custom(email_session, subject, html_template, context, attachment_path=None, signature_path=None, cc_key="EMAIL_CC_DESPACHO"):
     """Envía un correo usando una plantilla HTML personalizada."""
     if signature_path:
         context = dict(context)
@@ -97,7 +97,7 @@ def send_email_custom(email_session, subject, html_template, context, attachment
     msg["Subject"] = subject.upper()
     msg["From"] = email_session["address"]
     msg["To"] = context.get("email_to", "")
-    cc = get_cc_address()
+    cc = get_cc_address(cc_key)
     if cc:
         msg["Cc"] = cc
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ GestorCompras - Versión Preliminar
   3. Configuración de la Base de Datos:
      La base de datos SQLite se inicializa automáticamente al ejecutar la aplicación. Los datos se almacenan en el directorio "data".
   4. Configurar correos en copia (CC) *(opcional)*:
-     Desde la ventana de **Configuración** puede ingresar hasta 9 direcciones separadas por `;` en el campo CC.
-     También puede definir la variable de entorno `EMAIL_CC` con el mismo formato. Si se deja vacío, no se enviarán copias.
+     Ahora existen dos campos en la ventana de **Configuración** para definir las copias de seguimiento y de solicitudes de despacho.
+     En cada uno se pueden ingresar hasta 9 direcciones separadas por `;`.
+     También puede definir las variables de entorno `EMAIL_CC_SEGUIMIENTO` o `EMAIL_CC_DESPACHO` con el mismo formato.
   5. Carga rápida de Proveedores:
      Se incluye el script "import_proveedores.py" que permite agregar de forma rápida proveedores a la base de datos a partir de un archivo Excel (correos.xlsx). Para ejecutarlo, desde el directorio del proyecto, ejecute:
        python import_proveedores.py


### PR DESCRIPTION
## Summary
- split general configuration into Tracking and Dispatch tabs
- support separate CC addresses for tracking and dispatch emails
- add email template choice in dispatch module
- show process status headers in tracking and dispatch GUIs
- allow sending tracking emails without attached PDF
- update documentation for new CC fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686544a8a0c883209daaf0b6601df1eb