### PR TITLE
feat: integrate placeholder for Descarga de OC module

### DIFF
--- a/GestorCompras_/gestorcompras/gui/descarga_oc_gui.py
+++ b/GestorCompras_/gestorcompras/gui/descarga_oc_gui.py
@@ -1,0 +1,18 @@
+import tkinter as tk
+from tkinter import ttk
+
+def open_descarga_oc(master, email_session):
+    """Placeholder window for Descarga de OC module."""
+    window = tk.Toplevel(master)
+    window.title("Descarga de OC")
+    window.geometry("600x400")
+    window.transient(master)
+    window.grab_set()
+
+    frame = ttk.Frame(window, padding=10, style="MyFrame.TFrame")
+    frame.pack(fill="both", expand=True)
+
+    label = ttk.Label(frame,
+                      text="Módulo Descarga de OC en desarrollo",
+                      style="MyLabel.TLabel")
+    label.pack(pady=20)

--- a/GestorCompras_/gestorcompras/main.py
+++ b/GestorCompras_/gestorcompras/main.py
@@ -6,6 +6,7 @@ from gestorcompras.gui import config_gui
 from gestorcompras.gui import reasignacion_gui
 from gestorcompras.gui import despacho_gui
 from gestorcompras.gui import seguimientos_gui
+from gestorcompras.gui import descarga_oc_gui
 
 # Palette
 bg_base = "#F0F4F8"
@@ -161,6 +162,7 @@ class MainMenu(tk.Frame):
             ("Reasignación de Tareas", self.open_reasignacion),
             ("Solicitud de Despachos", self.open_despacho),
             ("Seguimientos", self.open_seguimientos),
+            ("Descarga de OC", self.open_descarga_oc),
             ("Cotizador", self.open_cotizador),
             ("Configuración", self.open_config),
             ("Salir", self.master.quit)
@@ -177,7 +179,10 @@ class MainMenu(tk.Frame):
 
     def open_seguimientos(self):
         seguimientos_gui.open_seguimientos(self.master, email_session)
-    
+
+    def open_descarga_oc(self):
+        descarga_oc_gui.open_descarga_oc(self.master, email_session)
+
     def open_config(self):
         config_gui.open_config_gui(self.master)
     


### PR DESCRIPTION
## Summary
- add placeholder GUI for Descarga de OC
- link new module from main menu

## Testing
- `cd GestorCompras_ && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6681a2ffc832094e940397af31797