### PR TITLE
Integrate DescargasOC into main menu

### DIFF
--- a/DescargasOC-main/descargas_oc/ui.py
+++ b/DescargasOC-main/descargas_oc/ui.py
@@ -63,9 +63,7 @@ def realizar_escaneo(text_widget: tk.Text, lbl_last: tk.Label):
         scanning_lock.release()
 
 
-def main():
-    root = tk.Tk()
-    root.title("Descargas OC")
+def _build_interface(root: tk.Misc) -> tk.Misc:
     root.lift()
     root.attributes('-topmost', True)
 
@@ -138,6 +136,19 @@ def main():
     btn_interval = tk.Button(frame, text="Guardar", command=actualizar_intervalo)
     btn_interval.pack(side=tk.LEFT, padx=5)
 
+    return root
+
+
+def open_window(parent: tk.Misc) -> tk.Misc:
+    window = tk.Toplevel(parent)
+    window.title("Descargas OC")
+    return _build_interface(window)
+
+
+def main():
+    root = tk.Tk()
+    root.title("Descargas OC")
+    _build_interface(root)
     root.mainloop()
 
 

--- a/GestorCompras_/gestorcompras/main.py
+++ b/GestorCompras_/gestorcompras/main.py
@@ -1,11 +1,18 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 import smtplib
+import sys
+from pathlib import Path
 from gestorcompras.services import db
 from gestorcompras.gui import config_gui
 from gestorcompras.gui import reasignacion_gui
 from gestorcompras.gui import despacho_gui
 from gestorcompras.gui import seguimientos_gui
+
+DESCARGAS_OC_DIR = Path(__file__).resolve().parents[2] / "DescargasOC-main"
+if str(DESCARGAS_OC_DIR) not in sys.path:
+    sys.path.append(str(DESCARGAS_OC_DIR))
+from descargas_oc import ui as descargas_ui
 
 # Palette
 bg_base = "#F0F4F8"
@@ -161,6 +168,7 @@ class MainMenu(tk.Frame):
             ("Reasignación de Tareas", self.open_reasignacion),
             ("Solicitud de Despachos", self.open_despacho),
             ("Seguimientos", self.open_seguimientos),
+            ("Descargas OC", self.open_descargas_oc),
             ("Cotizador", self.open_cotizador),
             ("Configuración", self.open_config),
             ("Salir", self.master.quit)
@@ -180,9 +188,12 @@ class MainMenu(tk.Frame):
     
     def open_config(self):
         config_gui.open_config_gui(self.master)
-    
+
     def open_cotizador(self):
         messagebox.showinfo("Cotizador", "Esta opción se encuentra en desarrollo")
+
+    def open_descargas_oc(self):
+        descargas_ui.open_window(self.master.winfo_toplevel())
 
 def main():
     db.init_db()


### PR DESCRIPTION
## Summary
- Refactor Descargas OC UI to expose a window builder for embedding
- Import Descargas OC as a package and open its interface directly from the main menu

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests_mock')*
- `pip install requests_mock` *(fails: Could not find a version that satisfies the requirement requests_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68b77eab12d8832092fed15c4c2da6fd