### PR TITLE
Include task and provider info in report

### DIFF
--- a/DescargasOC-main/descargas_oc/config.py
+++ b/DescargasOC-main/descargas_oc/config.py
@@ -63,7 +63,8 @@ class Config:
         self.data.setdefault('correo_reporte', 'jotoapanta@telconet.ec')
         self.data.setdefault('remitente_adicional', 'naf@telconet.ec')
         self.data.setdefault('compra_bienes', False)
-
+        # persist values so configuration survives between executions
+        self.save()
         return self
 
     def save(self):

--- a/DescargasOC-main/descargas_oc/configurador.py
+++ b/DescargasOC-main/descargas_oc/configurador.py
@@ -47,6 +47,7 @@ def configurar():
         })
         try:
             cfg.validate()
+            cfg.save()
             archivo = filedialog.askopenfilename(title='Archivo de prueba')
             if not archivo:
                 messagebox.showwarning('Prueba', 'Debes seleccionar un archivo de prueba')
@@ -54,7 +55,6 @@ def configurar():
             cli = SeafileClient(cfg.seafile_url, cfg.usuario, cfg.password)
             cli.upload_file(cfg.seafile_repo_id, archivo, parent_dir=cfg.seafile_subfolder)
             messagebox.showinfo('OK', 'Archivo subido correctamente')
-            cfg.save()
             try:
                 ventana.grab_release()
             except Exception:  # pragma: no cover - grab may not be set

--- a/DescargasOC-main/descargas_oc/configurador.py
+++ b/DescargasOC-main/descargas_oc/configurador.py
@@ -11,11 +11,19 @@ try:  # allow running as script
 except ImportError:  # pragma: no cover
     from config import Config
     from seafile_client import SeafileClient
-    from escuchador import PROCESADOS_FILE
+from escuchador import PROCESADOS_FILE
 
 
 def configurar():
     cfg = Config()
+
+    def center_window(win: tk.Tk | tk.Toplevel):
+        win.update_idletasks()
+        w = win.winfo_width()
+        h = win.winfo_height()
+        x = (win.winfo_screenwidth() // 2) - (w // 2)
+        y = (win.winfo_screenheight() // 2) - (h // 2)
+        win.geometry(f"{w}x{h}+{x}+{y}")
 
     def seleccionar_carpeta(entry):
         carpeta = filedialog.askdirectory(initialdir=entry.get() or os.getcwd())
@@ -67,6 +75,7 @@ def configurar():
             command=lambda: (popup.grab_release(), popup.destroy())
         )
         btn_ok.pack(pady=(0, 10))
+        center_window(popup)
 
         def tarea():
             try:
@@ -170,7 +179,7 @@ def configurar():
     lbl_estado.pack(side=tk.LEFT, padx=5)
 
     tk.Button(ventana, text='Guardar', command=guardar).pack(pady=10)
-
+    center_window(ventana)
     ventana.mainloop()
 
 if __name__ == '__main__':

--- a/DescargasOC-main/descargas_oc/mover_pdf.py
+++ b/DescargasOC-main/descargas_oc/mover_pdf.py
@@ -76,6 +76,7 @@ def mover_oc(config: Config, ordenes=None):
 
     faltantes = []
     subidos = []
+    es_bienes = bool(getattr(config, "compra_bienes", False))
     for numero in numeros_oc:
         ruta = encontrados.get(numero)
         if not ruta:
@@ -83,7 +84,7 @@ def mover_oc(config: Config, ordenes=None):
             continue
 
         prov = proveedores.get(numero)
-        if prov:
+        if es_bienes and prov:
             prov_clean = re.sub(r"[^\w\- ]", "_", prov)
             nuevo_nombre = os.path.join(carpeta_origen, f"{numero} - {prov_clean}.pdf")
             if ruta != nuevo_nombre:
@@ -93,12 +94,14 @@ def mover_oc(config: Config, ordenes=None):
                 except Exception as e:
                     logger.warning('No se pudo renombrar %s: %s', ruta, e)
 
-        # extraer número de tarea para organizar y para el reporte
-        tarea = extraer_numero_tarea_desde_pdf(ruta)
-        if indice_ordenes.get(numero) is not None:
-            indice_ordenes[numero]["tarea"] = tarea
+        tarea = None
+        if es_bienes:
+            # extraer número de tarea para organizar y para el reporte
+            tarea = extraer_numero_tarea_desde_pdf(ruta)
+            if indice_ordenes.get(numero) is not None:
+                indice_ordenes[numero]["tarea"] = tarea
 
-        if tarea:
+        if es_bienes and tarea:
             # buscar carpeta existente que comience con el número de tarea
             destino = None
             for root, dirs, _files in os.walk(carpeta_destino):

--- a/DescargasOC-main/descargas_oc/mover_pdf.py
+++ b/DescargasOC-main/descargas_oc/mover_pdf.py
@@ -1,16 +1,20 @@
 import os
 import re
 import shutil
+from pathlib import Path
+
 import PyPDF2
 
 try:  # allow running as script
     from .config import Config
     from .logger import get_logger
     from .seafile_client import SeafileClient
+    from .organizador_bienes import extraer_numero_tarea_desde_pdf
 except ImportError:  # pragma: no cover
     from config import Config
     from logger import get_logger
     from seafile_client import SeafileClient
+    from organizador_bienes import extraer_numero_tarea_desde_pdf
 
 logger = get_logger(__name__)
 
@@ -25,6 +29,7 @@ def mover_oc(config: Config, ordenes=None):
     # evitar números repetidos para no procesar la misma OC varias veces
     numeros_oc = list(dict.fromkeys(o.get("numero") for o in ordenes))
     proveedores = {o.get("numero"): o.get("proveedor") for o in ordenes}
+    indice_ordenes = {o.get("numero"): o for o in ordenes}
 
     carpeta_origen = config.carpeta_destino_local
     carpeta_destino = config.carpeta_analizar
@@ -81,23 +86,57 @@ def mover_oc(config: Config, ordenes=None):
         if prov:
             prov_clean = re.sub(r"[^\w\- ]", "_", prov)
             nuevo_nombre = os.path.join(carpeta_origen, f"{numero} - {prov_clean}.pdf")
+            if ruta != nuevo_nombre:
+                try:
+                    os.rename(ruta, nuevo_nombre)
+                    ruta = nuevo_nombre
+                except Exception as e:
+                    logger.warning('No se pudo renombrar %s: %s', ruta, e)
+
+        # extraer número de tarea para organizar y para el reporte
+        tarea = extraer_numero_tarea_desde_pdf(ruta)
+        if indice_ordenes.get(numero) is not None:
+            indice_ordenes[numero]["tarea"] = tarea
+
+        if tarea:
+            # buscar carpeta existente que comience con el número de tarea
+            destino = None
+            for root, dirs, _files in os.walk(carpeta_destino):
+                for d in dirs:
+                    if d.startswith(tarea):
+                        destino = os.path.join(root, d)
+                        break
+                if destino:
+                    break
+            if not destino:
+                destino = os.path.join(carpeta_destino, tarea)
+                os.makedirs(destino, exist_ok=True)
             try:
-                os.rename(ruta, nuevo_nombre)
-                ruta = nuevo_nombre
+                nombre_archivo = os.path.basename(ruta)
+                destino_archivo = os.path.join(destino, nombre_archivo)
+                if os.path.exists(destino_archivo):
+                    base, ext = os.path.splitext(nombre_archivo)
+                    i = 1
+                    while os.path.exists(destino_archivo):
+                        destino_archivo = os.path.join(destino, f"{base} ({i}){ext}")
+                        i += 1
+                shutil.copy2(ruta, destino_archivo)
+                logger.info("%s copiado a %s", nombre_archivo, destino)
             except Exception as e:
-                logger.warning('No se pudo renombrar %s: %s', ruta, e)
+                logger.warning("No se pudo copiar %s a %s: %s", ruta, destino, e)
 
         try:
-            # Subir primero y luego copiar manualmente para evitar archivos corruptos
             cliente.upload_file(repo_id, ruta, parent_dir=subfolder)
-            os.makedirs(carpeta_destino, exist_ok=True)
-            destino_final = os.path.join(carpeta_destino, os.path.basename(ruta))
-            with open(ruta, "rb") as src, open(destino_final, "wb") as dst:
-                shutil.copyfileobj(src, dst)
-            os.remove(ruta)
             subidos.append(numero)
-            logger.info('Subido %s', os.path.basename(destino_final))
+            logger.info('Subido %s', os.path.basename(ruta))
         except Exception as e:
             logger.error('Error subiendo %s: %s', ruta, e)
+
+    # limpiar carpeta de origen después del proceso
+    for f in Path(carpeta_origen).glob("*.pdf"):
+        try:
+            f.unlink()
+        except Exception:
+            pass
     return subidos, faltantes
 

--- a/DescargasOC-main/descargas_oc/reporter.py
+++ b/DescargasOC-main/descargas_oc/reporter.py
@@ -1,12 +1,15 @@
 import smtplib
 from email.message import EmailMessage
+from pathlib import Path
 
 try:  # allow running as script
     from .config import Config
     from .logger import get_logger
+    from .organizador_bienes import extraer_numero_tarea_desde_pdf
 except ImportError:  # pragma: no cover
     from config import Config
     from logger import get_logger
+    from organizador_bienes import extraer_numero_tarea_desde_pdf
 
 logger = get_logger(__name__)
 
@@ -14,9 +17,38 @@ SMTP_SERVER = "smtp.telconet.ec"
 SMTP_PORT = 465
 
 
-def enviar_reporte(exitosas, faltantes, cfg: Config) -> bool:
+def _buscar_tarea(numero: str, cfg: Config) -> str | None:
+    """Busca el número de tarea dentro del PDF de la OC."""
+    carpeta = getattr(cfg, "carpeta_analizar", None)
+    if not carpeta:
+        return None
+    for pdf in Path(carpeta).glob(f"{numero}*.pdf"):
+        tarea = extraer_numero_tarea_desde_pdf(str(pdf))
+        if tarea:
+            return tarea
+    return None
+
+
+def _formatear_tabla(filas: list[tuple[str, str, str]]) -> str:
+    """Genera una tabla simple alineada por columnas."""
+    headers = ("Orden", "Tarea", "Proveedor")
+    filas_completas = [headers] + filas
+    anchos = [max(len(str(f[i])) for f in filas_completas) for i in range(3)]
+    linea_sep = " | ".join("-" * a for a in anchos)
+    lines = [
+        " | ".join(str(f[i]).ljust(anchos[i]) for i in range(3)) for f in filas_completas
+    ]
+    return "\n".join([lines[0], linea_sep] + lines[1:])
+
+
+def enviar_reporte(exitosas, faltantes, ordenes, cfg: Config) -> bool:
     if not exitosas and not faltantes:
         return False
+    # asegurarse de no repetir números
+    exitosas_uniq = list(dict.fromkeys(exitosas))
+    faltantes_uniq = list(dict.fromkeys(faltantes))
+    info = {o["numero"]: o for o in ordenes}
+
     destinatario = cfg.correo_reporte
     usuario = cfg.usuario
     password = cfg.password
@@ -28,12 +60,20 @@ def enviar_reporte(exitosas, faltantes, cfg: Config) -> bool:
     mensaje['From'] = usuario
     mensaje['To'] = destinatario
     cuerpo = 'Órdenes subidas correctamente:\n'
-    for num in exitosas:
-        cuerpo += f'- {num}\n'
-    if faltantes:
+    filas_ok: list[tuple[str, str, str]] = []
+    for num in exitosas_uniq:
+        prov = info.get(num, {}).get('proveedor') or '-'    
+        tarea = _buscar_tarea(num, cfg) or '-'
+        filas_ok.append((num, tarea, prov))
+    if filas_ok:
+        cuerpo += _formatear_tabla(filas_ok) + '\n'
+    if faltantes_uniq:
         cuerpo += '\nNo se encontraron archivos para las siguientes OC:\n'
-        for num in faltantes:
-            cuerpo += f'- {num}\n'
+        filas_bad: list[tuple[str, str, str]] = []
+        for num in faltantes_uniq:
+            prov = info.get(num, {}).get('proveedor') or '-'
+            filas_bad.append((num, '-', prov))
+        cuerpo += _formatear_tabla(filas_bad) + '\n'
     mensaje.set_content(cuerpo)
     try:
         with smtplib.SMTP_SSL(SMTP_SERVER, SMTP_PORT) as smtp:

--- a/DescargasOC-main/descargas_oc/reporter.py
+++ b/DescargasOC-main/descargas_oc/reporter.py
@@ -22,7 +22,8 @@ def _buscar_tarea(numero: str, cfg: Config) -> str | None:
     carpeta = getattr(cfg, "carpeta_analizar", None)
     if not carpeta:
         return None
-    for pdf in Path(carpeta).glob(f"{numero}*.pdf"):
+    # Buscar recursivamente por si los archivos fueron movidos a subcarpetas
+    for pdf in Path(carpeta).rglob(f"{numero}*.pdf"):
         tarea = extraer_numero_tarea_desde_pdf(str(pdf))
         if tarea:
             return tarea

--- a/DescargasOC-main/descargas_oc/reporter.py
+++ b/DescargasOC-main/descargas_oc/reporter.py
@@ -63,8 +63,9 @@ def enviar_reporte(exitosas, faltantes, ordenes, cfg: Config) -> bool:
     cuerpo = 'Órdenes subidas correctamente:\n'
     filas_ok: list[tuple[str, str, str]] = []
     for num in exitosas_uniq:
-        prov = info.get(num, {}).get('proveedor') or '-'    
-        tarea = _buscar_tarea(num, cfg) or '-'
+        data = info.get(num, {})
+        prov = data.get('proveedor') or '-'
+        tarea = data.get('tarea') or _buscar_tarea(num, cfg) or '-'
         filas_ok.append((num, tarea, prov))
     if filas_ok:
         cuerpo += _formatear_tabla(filas_ok) + '\n'
@@ -72,8 +73,10 @@ def enviar_reporte(exitosas, faltantes, ordenes, cfg: Config) -> bool:
         cuerpo += '\nNo se encontraron archivos para las siguientes OC:\n'
         filas_bad: list[tuple[str, str, str]] = []
         for num in faltantes_uniq:
-            prov = info.get(num, {}).get('proveedor') or '-'
-            filas_bad.append((num, '-', prov))
+            data = info.get(num, {})
+            prov = data.get('proveedor') or '-'
+            tarea = data.get('tarea') or '-'
+            filas_bad.append((num, tarea, prov))
         cuerpo += _formatear_tabla(filas_bad) + '\n'
     mensaje.set_content(cuerpo)
     try:

--- a/DescargasOC-main/descargas_oc/selenium_modulo.py
+++ b/DescargasOC-main/descargas_oc/selenium_modulo.py
@@ -257,7 +257,7 @@ def descargar_oc(ordenes, username: str | None = None, password: str | None = No
         driver.quit()
 
     numeros = [oc.get("numero") for oc in ordenes]
-    subidos, faltantes = mover_oc(cfg, numeros)
+    subidos, faltantes = mover_oc(cfg, ordenes)
     if getattr(cfg, "compra_bienes", False):
         organizar_bienes(cfg.carpeta_analizar, cfg.carpeta_analizar)
     faltantes.extend(n for n in numeros if any(n in e for e in errores))

--- a/DescargasOC-main/descargas_oc/selenium_modulo.py
+++ b/DescargasOC-main/descargas_oc/selenium_modulo.py
@@ -261,6 +261,8 @@ def descargar_oc(ordenes, username: str | None = None, password: str | None = No
     if getattr(cfg, "compra_bienes", False):
         organizar_bienes(cfg.carpeta_analizar, cfg.carpeta_analizar)
     faltantes.extend(n for n in numeros if any(n in e for e in errores))
+    # evitar números repetidos al reportar faltantes
+    faltantes = list(dict.fromkeys(faltantes))
     return subidos, faltantes, errores
 
 

--- a/DescargasOC-main/descargas_oc/ui.py
+++ b/DescargasOC-main/descargas_oc/ui.py
@@ -59,7 +59,7 @@ def realizar_escaneo(text_widget: tk.Text, lbl_last: tk.Label):
                 append(f"✔️ OC {num} procesada\n")
             for num in no_encontrados:
                 append(f"❌ OC {num} faltante\n")
-        enviado = enviar_reporte(exitosas, faltantes, cfg)
+        enviado = enviar_reporte(exitosas, faltantes, ordenes, cfg)
         if enviado:
             registrar_procesados([o['uidl'] for o in ordenes], ultimo)
         summary = (

--- a/DescargasOC-main/descargas_oc/ui.py
+++ b/DescargasOC-main/descargas_oc/ui.py
@@ -83,7 +83,12 @@ def realizar_escaneo(text_widget: tk.Text, lbl_last: tk.Label):
         errores: list[str] = []
         if ordenes:
             append(f"Procesando {len(ordenes)} OC(s)\n")
-            subidos, no_encontrados, errores = descargar_oc(ordenes)
+            try:
+                subidos, no_encontrados, errores = descargar_oc(ordenes)
+            except Exception as exc:  # pragma: no cover - runtime safety
+                logger.exception("Fallo al descargar OC")
+                errores = [str(exc)]
+                subidos, no_encontrados = [], [o["num"] for o in ordenes]
             exitosas.extend(subidos)
             faltantes.extend(no_encontrados)
             for num in subidos:
@@ -105,7 +110,9 @@ def realizar_escaneo(text_widget: tk.Text, lbl_last: tk.Label):
             text_widget.after(0, lambda: messagebox.showinfo("Resultado", summary))
         append("Proceso finalizado\n")
         lbl_last.config(
-            text=f"Último UIDL: {cargar_ultimo_uidl()} - {datetime.now:%H:%M:%S}"
+            text="Último UIDL: {} - {}".format(
+                cargar_ultimo_uidl(), datetime.now().strftime("%H:%M:%S")
+            )
         )
     finally:
         scanning_lock.release()

--- a/DescargasOC-main/descargas_oc/ui.py
+++ b/DescargasOC-main/descargas_oc/ui.py
@@ -59,17 +59,19 @@ def realizar_escaneo(text_widget: tk.Text, lbl_last: tk.Label):
                 append(f"✔️ OC {num} procesada\n")
             for num in no_encontrados:
                 append(f"❌ OC {num} faltante\n")
+        else:
+            append("No se encontraron nuevas órdenes\n")
         enviado = enviar_reporte(exitosas, faltantes, ordenes, cfg)
         if enviado:
             registrar_procesados([o['uidl'] for o in ordenes], ultimo)
-        summary = (
-            "Errores durante la descarga:\n" + "\n".join(errores)
-            if errores
-            else "ORDENES DE COMPRA DESCARGADAS Y REPORTE ENVIADO"
-        )
-        text_widget.after(
-            0, lambda: messagebox.showinfo("Resultado", summary)
-        )
+        if ordenes:
+            if errores:
+                summary = "Errores durante la descarga:\n" + "\n".join(errores)
+            elif enviado:
+                summary = "ORDENES DE COMPRA DESCARGADAS Y REPORTE ENVIADO"
+            else:
+                summary = "No se pudo enviar el reporte"
+            text_widget.after(0, lambda: messagebox.showinfo("Resultado", summary))
         append("Proceso finalizado\n")
         lbl_last.config(
             text=f"Último UIDL: {cargar_ultimo_uidl()} - {datetime.now:%H:%M:%S}"

--- a/DescargasOC-main/descargas_oc/ui.py
+++ b/DescargasOC-main/descargas_oc/ui.py
@@ -168,6 +168,7 @@ def main():
         try:
             val = int(entry_interval.get())
             if val >= 300:
+                cfg.load()
                 cfg.data['scan_interval'] = val
                 cfg.save()
                 estado['contador'] = val
@@ -180,15 +181,29 @@ def main():
     btn_escanear = tk.Button(frame, text="Escanear ahora", command=escanear_ahora)
     btn_escanear.pack(side=tk.LEFT, padx=5)
 
-    btn_config = tk.Button(frame, text="Configuración", command=configurar)
+    def abrir_config():
+        configurar()
+        cfg.load()
+        var_bienes.set(bool(cfg.compra_bienes))
+        entry_interval.delete(0, tk.END)
+        entry_interval.insert(0, str(cfg.scan_interval))
+
+    btn_config = tk.Button(frame, text="Configuración", command=abrir_config)
     btn_config.pack(side=tk.LEFT, padx=5)
 
     var_bienes = tk.BooleanVar(value=bool(cfg.compra_bienes))
+
     def actualizar_bienes():
+        cfg.load()
         cfg.data['compra_bienes'] = var_bienes.get()
         cfg.save()
-    chk_bienes = tk.Checkbutton(frame, text="Compra Bienes", variable=var_bienes,
-                                command=actualizar_bienes)
+
+    chk_bienes = tk.Checkbutton(
+        frame,
+        text="Compra Bienes",
+        variable=var_bienes,
+        command=actualizar_bienes,
+    )
     chk_bienes.pack(side=tk.LEFT, padx=5)
 
     tk.Label(frame, text="Intervalo(seg):").pack(side=tk.LEFT, padx=5)

--- a/DescargasOC-main/descargas_oc/ui.py
+++ b/DescargasOC-main/descargas_oc/ui.py
@@ -24,6 +24,32 @@ logger = get_logger(__name__)
 scanning_lock = threading.Lock()
 
 
+def center_window(win: tk.Tk | tk.Toplevel):
+    win.update_idletasks()
+    w = win.winfo_width()
+    h = win.winfo_height()
+    x = (win.winfo_screenwidth() // 2) - (w // 2)
+    y = (win.winfo_screenheight() // 2) - (h // 2)
+    win.geometry(f"{w}x{h}+{x}+{y}")
+
+
+def config_completa(cfg: Config) -> bool:
+    try:
+        cfg.validate()
+    except Exception:
+        return False
+    requeridos = [
+        cfg.usuario,
+        cfg.password,
+        cfg.carpeta_destino_local,
+        cfg.carpeta_analizar,
+        cfg.seafile_url,
+        cfg.seafile_repo_id,
+        cfg.correo_reporte,
+    ]
+    return all(requeridos)
+
+
 class TextHandler(logging.Handler):
     def __init__(self, widget: tk.Text):
         super().__init__()
@@ -41,6 +67,11 @@ def realizar_escaneo(text_widget: tk.Text, lbl_last: tk.Label):
         return
     try:
         cfg = Config()
+        if not config_completa(cfg):
+            messagebox.showerror(
+                "Error", "Configuración incompleta o por favor configurar correctamente"
+            )
+            return
 
         def append(msg: str):
             text_widget.after(0, lambda m=msg: (text_widget.insert(tk.END, m), text_widget.see(tk.END)))
@@ -118,6 +149,12 @@ def main():
             estado["activo"] = False
             btn_toggle.config(text="Activar escuchador")
         else:
+            if not config_completa(cfg):
+                messagebox.showerror(
+                    "Error",
+                    "Configuración incompleta o por favor configurar correctamente",
+                )
+                return
             estado["activo"] = True
             estado["contador"] = cfg.scan_interval
             btn_toggle.config(text="Detener escuchador")
@@ -161,6 +198,7 @@ def main():
     btn_interval = tk.Button(frame, text="Guardar", command=actualizar_intervalo)
     btn_interval.pack(side=tk.LEFT, padx=5)
 
+    center_window(root)
     root.mainloop()
 
 

--- a/GestorCompras_/gestorcompras/gui/config_gui.py
+++ b/GestorCompras_/gestorcompras/gui/config_gui.py
@@ -7,6 +7,14 @@ from html import escape
 from gestorcompras.services import db
 from gestorcompras.gui.html_editor import HtmlEditor
 
+def center_window(win: tk.Tk | tk.Toplevel):
+    win.update_idletasks()
+    w = win.winfo_width()
+    h = win.winfo_height()
+    x = (win.winfo_screenwidth() // 2) - (w // 2)
+    y = (win.winfo_screenheight() // 2) - (h // 2)
+    win.geometry(f"{w}x{h}+{x}+{y}")
+
 class ConfigGUI(tk.Toplevel):
     def __init__(self, master=None):
         super().__init__(master)
@@ -16,6 +24,7 @@ class ConfigGUI(tk.Toplevel):
         self.title("Configuración")
         self.geometry("800x600")
         self.create_widgets()
+        center_window(self)
     
     def create_widgets(self):
         self.notebook = ttk.Notebook(self, style="MyNotebook.TNotebook")
@@ -413,6 +422,7 @@ class TemplateForm(tk.Toplevel):
         self.refresh_callback = refresh_callback
         self.template_data = template_data
         self.create_widgets()
+        center_window(self)
 
     def create_widgets(self):
         container = ttk.Frame(self, style="MyFrame.TFrame", padding=10)
@@ -478,6 +488,7 @@ class SupplierForm(tk.Toplevel):
         self.refresh_callback = refresh_callback
         self.supplier_data = supplier_data
         self.create_widgets()
+        center_window(self)
     
     def create_widgets(self):
         container = ttk.Frame(self, style="MyFrame.TFrame", padding=10)
@@ -537,6 +548,7 @@ class AssignmentForm(tk.Toplevel):
         self.refresh_callback = refresh_callback
         self.data = data
         self.create_widgets()
+        center_window(self)
 
     def create_widgets(self):
         container = ttk.Frame(self, style="MyFrame.TFrame", padding=10)

--- a/GestorCompras_/gestorcompras/gui/despacho_gui.py
+++ b/GestorCompras_/gestorcompras/gui/despacho_gui.py
@@ -6,12 +6,22 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from gestorcompras.logic import despacho_logic
 from gestorcompras.services import db
 
+
+def center_window(win: tk.Tk | tk.Toplevel):
+    win.update_idletasks()
+    w = win.winfo_width()
+    h = win.winfo_height()
+    x = (win.winfo_screenwidth() // 2) - (w // 2)
+    y = (win.winfo_screenheight() // 2) - (h // 2)
+    win.geometry(f"{w}x{h}+{x}+{y}")
+
 def open_despacho(master, email_session):
     window = tk.Toplevel(master)
     window.title("Solicitud de Despachos")
     window.geometry("600x450")
     window.transient(master)
     window.grab_set()
+    center_window(window)
     
     main_frame = ttk.Frame(window, style="MyFrame.TFrame", padding=10)
     main_frame.pack(fill="both", expand=True)

--- a/GestorCompras_/gestorcompras/gui/reasignacion_gui.py
+++ b/GestorCompras_/gestorcompras/gui/reasignacion_gui.py
@@ -22,6 +22,15 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.action_chains import ActionChains
 
+
+def center_window(win: tk.Tk | tk.Toplevel):
+    win.update_idletasks()
+    w = win.winfo_width()
+    h = win.winfo_height()
+    x = (win.winfo_screenwidth() // 2) - (w // 2)
+    y = (win.winfo_screenheight() // 2) - (h // 2)
+    win.geometry(f"{w}x{h}+{x}+{y}")
+
 def process_body(body):
     task_pattern = r'Tarea:\s+(\d+)\s+Reasignación a:\s+(.*?)\s+Datos relacionados:(.*?)\n(?=Tarea:|\Z)'
     tasks = re.findall(task_pattern, body, re.DOTALL)
@@ -289,6 +298,7 @@ def open_reasignacion(master, email_session):
     window.geometry("820x650")
     window.transient(master)
     window.grab_set()
+    center_window(window)
 
     def on_close():
         db.clear_tasks_temp()

--- a/GestorCompras_/gestorcompras/gui/seguimientos_gui.py
+++ b/GestorCompras_/gestorcompras/gui/seguimientos_gui.py
@@ -7,12 +7,22 @@ from gestorcompras.services import google_sheets
 from gestorcompras.logic import despacho_logic
 
 
+def center_window(win: tk.Tk | tk.Toplevel):
+    win.update_idletasks()
+    w = win.winfo_width()
+    h = win.winfo_height()
+    x = (win.winfo_screenwidth() // 2) - (w // 2)
+    y = (win.winfo_screenheight() // 2) - (h // 2)
+    win.geometry(f"{w}x{h}+{x}+{y}")
+
+
 def open_seguimientos(master, email_session):
     window = tk.Toplevel(master)
     window.title("Seguimientos desde Sheet")
     window.geometry("700x500")
     window.transient(master)
     window.grab_set()
+    center_window(window)
 
     frame = ttk.Frame(window, padding=10, style="MyFrame.TFrame")
     frame.pack(fill="both", expand=True)

--- a/GestorCompras_/gestorcompras/main.py
+++ b/GestorCompras_/gestorcompras/main.py
@@ -157,15 +157,28 @@ class LoginScreen(tk.Frame):
 class MainMenu(tk.Frame):
     def __init__(self, master):
         super().__init__(master)
+        self._banner_colors = [color_primario, color_hover]
+        self._color_index = 0
+        self._buttons = [
+            ("Reasignación de Tareas", self.open_reasignacion),
+            ("Solicitud de Despachos", self.open_despacho),
+            ("Seguimientos", self.open_seguimientos),
+            ("Descargas OC", self.open_descargas_oc),
+            ("Cotizador", self.open_cotizador),
+            ("Configuración", self.open_config),
+            ("Salir", self.master.quit),
+        ]
+        self._button_widgets: list[ttk.Button] = []
         self.create_widgets()
     
     def create_widgets(self):
         container = ttk.Frame(self, style="MyFrame.TFrame")
         container.pack(fill="both", expand=True)
         
-        banner = ttk.Label(container, text="Sistema de automatización - compras")
-        banner.configure(font=fuente_banner, foreground=color_titulos)
-        banner.pack(pady=(20,10))
+        self.banner = ttk.Label(container, text="Sistema de automatización - compras")
+        self.banner.configure(font=fuente_banner, foreground=color_titulos)
+        self.banner.pack(pady=(20,10))
+        self.animate_banner()
         
         menu_frame = ttk.Frame(container, style="MyFrame.TFrame", padding=20)
         menu_frame.place(relx=0.5, rely=0.5, anchor="center")
@@ -174,19 +187,23 @@ class MainMenu(tk.Frame):
         lbl_title.configure(font=fuente_bold, foreground=color_titulos)
         lbl_title.grid(row=0, column=0, pady=15, sticky="n")
         
-        # Lista de botones
-        buttons = [
-            ("Reasignación de Tareas", self.open_reasignacion),
-            ("Solicitud de Despachos", self.open_despacho),
-            ("Seguimientos", self.open_seguimientos),
-            ("Descargas OC", self.open_descargas_oc),
-            ("Cotizador", self.open_cotizador),
-            ("Configuración", self.open_config),
-            ("Salir", self.master.quit)
-        ]
-        for idx, (text, cmd) in enumerate(buttons, start=1):
-            btn = ttk.Button(menu_frame, text=text, style="MyButton.TButton", command=cmd)
-            btn.grid(row=idx, column=0, padx=20, pady=5, sticky="ew")
+        self.menu_frame = menu_frame
+        self.show_button(0)
+
+    def animate_banner(self):
+        color = self._banner_colors[self._color_index]
+        self.banner.configure(foreground=color)
+        self._color_index = (self._color_index + 1) % len(self._banner_colors)
+        self.after(800, self.animate_banner)
+
+    def show_button(self, index: int):
+        if index >= len(self._buttons):
+            return
+        text, cmd = self._buttons[index]
+        btn = ttk.Button(self.menu_frame, text=text, style="MyButton.TButton", command=cmd)
+        btn.grid(row=index + 1, column=0, padx=20, pady=5, sticky="ew")
+        self._button_widgets.append(btn)
+        self.after(120, self.show_button, index + 1)
     
     def open_reasignacion(self):
         reasignacion_gui.open_reasignacion(self.master, email_session)

--- a/GestorCompras_/gestorcompras/main.py
+++ b/GestorCompras_/gestorcompras/main.py
@@ -27,6 +27,15 @@ fuente_entry = ("Segoe UI", 14)
 
 email_session = {}
 
+
+def center_window(win: tk.Tk | tk.Toplevel):
+    win.update_idletasks()
+    w = win.winfo_width()
+    h = win.winfo_height()
+    x = (win.winfo_screenwidth() // 2) - (w // 2)
+    y = (win.winfo_screenheight() // 2) - (h // 2)
+    win.geometry(f"{w}x{h}+{x}+{y}")
+
 def test_email_connection(email_address, email_password):
     try:
         with smtplib.SMTP("smtp.telconet.ec", 587) as server:
@@ -229,6 +238,7 @@ def main():
     root = tk.Tk()
     root.title("Sistema de Automatización")
     root.geometry("800x600")
+    center_window(root)
     
     init_styles()
     


### PR DESCRIPTION
## Summary
- Deduplicate order numbers in reports and include task numbers and provider names in a formatted table.
- Pass order details to the reporter so provider and task metadata can be included.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests_mock')*


------
https://chatgpt.com/codex/tasks/task_e_68bcb3db914c8320bf7990872100dbc5