### PR TITLE
Add quote comparison utilities and market price lookup

### DIFF
--- a/GestorCompras_/gestorcompras/gui/cotizador_gui.py
+++ b/GestorCompras_/gestorcompras/gui/cotizador_gui.py
@@ -1,0 +1,105 @@
+"""Interfaz gráfica para comparar múltiples cotizaciones.
+
+Esta ventana permite cargar varios archivos de cotización (PDF o Excel),
+comparar los ítems detectados y recomendar el mejor precio disponible.  Los
+resultados se registran en la base de datos para auditoría y análisis futuro.
+"""
+from __future__ import annotations
+
+import os
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+from gestorcompras.services import quote_comparator, market_search, db
+
+
+class CotizadorGUI(tk.Toplevel):
+    def __init__(self, master: tk.Misc | None = None):
+        super().__init__(master)
+        # Aseguramos que la base de datos tenga todas las tablas necesarias
+        db.init_db()
+        self.title("Comparar cotizaciones")
+        self.geometry("700x500")
+        self.files: list[str] = []
+        self._create_widgets()
+
+    def _create_widgets(self):
+        frame = ttk.Frame(self, padding=10)
+        frame.pack(fill="both", expand=True)
+
+        btn_frame = ttk.Frame(frame)
+        btn_frame.pack(fill="x")
+        ttk.Button(btn_frame, text="Agregar archivos", command=self.add_files).pack(side="left")
+        ttk.Button(btn_frame, text="Comparar", command=self.compare).pack(side="left", padx=5)
+
+        columns = ("item", "best_price", "source")
+        self.tree = ttk.Treeview(frame, columns=columns, show="headings")
+        self.tree.heading("item", text="Item")
+        self.tree.heading("best_price", text="Mejor precio")
+        self.tree.heading("source", text="Fuente")
+        self.tree.pack(fill="both", expand=True, pady=10)
+
+    # ------------------ Acciones ------------------
+    def add_files(self):
+        paths = filedialog.askopenfilenames(
+            filetypes=[("Cotizaciones", "*.pdf *.xls *.xlsx"), ("Todos", "*.*")]
+        )
+        if not paths:
+            return
+        self.files.extend(paths)
+        messagebox.showinfo("Información", f"Se agregaron {len(paths)} archivo(s).")
+
+    def compare(self):
+        if len(self.files) < 2:
+            messagebox.showwarning(
+                "Advertencia", "Agregue al menos dos cotizaciones para comparar."
+            )
+            return
+
+        quotes = []
+        for path in self.files:
+            items = quote_comparator.parse_quote(path)
+            quotes.append({"source": os.path.basename(path), "items": items})
+
+        if not quotes or not quotes[0]["items"]:
+            messagebox.showerror(
+                "Error", "No se pudieron leer los ítems de las cotizaciones."
+            )
+            return
+
+        reference = quotes[0]
+        results = {}
+        for item in reference["items"]:
+            desc = item["description"]
+            best_price = item["price"]
+            best_source = reference["source"]
+            details = {reference["source"]: best_price}
+
+            for other in quotes[1:]:
+                matches = quote_comparator.match_items([desc], other["items"])
+                match = matches[0]
+                if match["quoted"] is not None:
+                    details[other["source"]] = match["quoted_price"]
+                    if match["quoted_price"] < best_price:
+                        best_price = match["quoted_price"]
+                        best_source = other["source"]
+
+            market = market_search.find_best_price(desc)
+            if market and market.get("price") is not None:
+                details[market["source"]] = market["price"]
+                if market["price"] < best_price:
+                    best_price = market["price"]
+                    best_source = market["source"]
+
+            results[desc] = {
+                "best_price": best_price,
+                "best_source": best_source,
+                "details": details,
+            }
+            db.log_quote_comparison(desc, best_source, best_price, details)
+
+        for row in self.tree.get_children():
+            self.tree.delete(row)
+        for desc, info in results.items():
+            self.tree.insert("", "end", values=(desc, info["best_price"], info["best_source"]))
+

--- a/GestorCompras_/gestorcompras/gui/cotizador_gui.py
+++ b/GestorCompras_/gestorcompras/gui/cotizador_gui.py
@@ -103,3 +103,9 @@ class CotizadorGUI(tk.Toplevel):
         for desc, info in results.items():
             self.tree.insert("", "end", values=(desc, info["best_price"], info["best_source"]))
 
+def open_cotizador(master: tk.Misc):
+    """Abrir la ventana de comparación de cotizaciones."""
+    window = CotizadorGUI(master)
+    window.transient(master)
+    window.grab_set()
+    window.wait_window()

--- a/GestorCompras_/gestorcompras/main.py
+++ b/GestorCompras_/gestorcompras/main.py
@@ -9,6 +9,7 @@ from gestorcompras.gui import config_gui
 from gestorcompras.gui import reasignacion_gui
 from gestorcompras.gui import despacho_gui
 from gestorcompras.gui import seguimientos_gui
+from gestorcompras.gui import cotizador_gui
 
 # Palette
 bg_base = "#F0F4F8"
@@ -231,7 +232,7 @@ class MainMenu(tk.Frame):
         config_gui.open_config_gui(self.master)
     
     def open_cotizador(self):
-        messagebox.showinfo("Cotizador", "Esta opción se encuentra en desarrollo")
+        cotizador_gui.open_cotizador(self.master)
 
 def main():
     db.init_db()

--- a/GestorCompras_/gestorcompras/services/market_search.py
+++ b/GestorCompras_/gestorcompras/services/market_search.py
@@ -1,0 +1,39 @@
+"""Herramientas básicas para consultar precios de mercado."""
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from typing import Optional, Dict, Any
+
+
+def find_best_price(item_description: str) -> Optional[Dict[str, Any]]:
+    """Busca el mejor precio disponible públicamente para un ítem.
+
+    La implementación utiliza la API pública de MercadoLibre. Si la petición
+    falla (por falta de conexión, timeouts u otros errores) simplemente retorna
+    ``None``.  Esta función está pensada como un punto de partida que puede ser
+    extendido con técnicas de *web scraping* controlado u otras APIs.
+    """
+    base_url = "https://api.mercadolibre.com/sites/MLA/search"
+    params = {"q": item_description}
+    url = f"{base_url}?{urllib.parse.urlencode(params)}"
+
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except Exception:
+        return None
+
+    results = data.get("results") or []
+    if not results:
+        return None
+
+    best = min(results, key=lambda r: r.get("price", float("inf")))
+    return {
+        "source": "MercadoLibre",
+        "title": best.get("title"),
+        "price": best.get("price"),
+        "link": best.get("permalink"),
+    }
+

--- a/GestorCompras_/gestorcompras/services/quote_comparator.py
+++ b/GestorCompras_/gestorcompras/services/quote_comparator.py
@@ -1,0 +1,112 @@
+import os
+import re
+from typing import List, Dict, Any
+
+import pandas as pd
+
+
+def parse_quote(file_path: str) -> List[Dict[str, Any]]:
+    """Parsea una cotización y retorna una lista de ítems con precio.
+
+    La función intenta detectar automáticamente el tipo de archivo. Si es un
+    Excel, se usa :func:`pandas.read_excel`.  Si es un PDF, se intenta extraer
+    texto mediante :mod:`pdfplumber` y se buscan patrones simples de
+    ``descripcion precio``.
+
+    Debido a que un flujo de OCR/LLM real está fuera del alcance del proyecto
+    actual, este procedimiento usa heurísticas básicas para lograr una
+    extracción aproximada de información.
+    """
+    ext = os.path.splitext(file_path)[1].lower()
+    items: List[Dict[str, Any]] = []
+
+    if ext in {".xls", ".xlsx"}:
+        df = pd.read_excel(file_path)
+        # Buscamos columnas habituales; si no existen tomamos las dos primeras
+        columns = [c.lower() for c in df.columns]
+        if "item" in columns and "price" in columns:
+            item_col = columns.index("item")
+            price_col = columns.index("price")
+            for _, row in df.iterrows():
+                desc = str(row.iloc[item_col]).strip()
+                try:
+                    price = float(row.iloc[price_col])
+                except Exception:
+                    continue
+                items.append({"description": desc, "price": price})
+        else:
+            # Heurística: asumimos que la primera columna es descripción y la
+            # segunda precio
+            for _, row in df.iloc[:, :2].iterrows():
+                desc = str(row.iloc[0]).strip()
+                try:
+                    price = float(row.iloc[1])
+                except Exception:
+                    continue
+                items.append({"description": desc, "price": price})
+    elif ext == ".pdf":
+        try:
+            import pdfplumber
+
+            with pdfplumber.open(file_path) as pdf:
+                text = "\n".join(page.extract_text() or "" for page in pdf.pages)
+            # Patrón muy simple: cualquier cosa seguida de un número con
+            # decimales opcionales
+            pattern = re.compile(r"(.+?)\s+([\d.,]+)")
+            for line in text.splitlines():
+                match = pattern.search(line)
+                if not match:
+                    continue
+                desc = match.group(1).strip()
+                price_str = match.group(2).replace(".", "").replace(",", ".")
+                try:
+                    price = float(price_str)
+                except Exception:
+                    continue
+                items.append({"description": desc, "price": price})
+        except Exception:
+            # Si la extracción falla simplemente devolvemos lo obtenido hasta
+            # ahora (que será la lista vacía)
+            pass
+    else:
+        # Otros formatos no soportados en esta implementación.
+        pass
+
+    return items
+
+
+def match_items(requested_items: List[str], quoted_items: List[Dict[str, Any]], threshold: float = 0.6) -> List[Dict[str, Any]]:
+    """Realiza un emparejamiento semántico básico entre ítems solicitados y
+    cotizados.
+
+    Se utiliza :class:`difflib.SequenceMatcher` para medir la similitud entre
+    descripciones.  En un escenario real se podría reemplazar por embeddings o
+    un modelo semántico avanzado.
+    """
+    from difflib import SequenceMatcher
+
+    matches = []
+    for req in requested_items:
+        best_match: Dict[str, Any] | None = None
+        best_score = 0.0
+        for item in quoted_items:
+            score = SequenceMatcher(None, req.lower(), item["description"].lower()).ratio()
+            if score > best_score:
+                best_score = score
+                best_match = item
+        if best_score >= threshold and best_match is not None:
+            matches.append({
+                "requested": req,
+                "quoted": best_match["description"],
+                "quoted_price": best_match["price"],
+                "score": best_score,
+            })
+        else:
+            matches.append({
+                "requested": req,
+                "quoted": None,
+                "quoted_price": None,
+                "score": best_score,
+            })
+    return matches
+


### PR DESCRIPTION
## Summary
- add quote comparator with parsing and semantic matching
- add market search service querying MercadoLibre
- create GUI for comparing quotes and logging best prices
- store comparison results in new quote_comparison_log table

## Testing
- `cd GestorCompras_ && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3ba7b57c08320b6c96d4ecb38dac0