### PR TITLE
Add initial Flask web interface and deployment guide

### DIFF
--- a/GestorCompras_/gestorcompras/main.py
+++ b/GestorCompras_/gestorcompras/main.py
@@ -1,6 +1,5 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
-import smtplib
 import subprocess
 import sys
 from pathlib import Path
@@ -9,6 +8,7 @@ from gestorcompras.gui import config_gui
 from gestorcompras.gui import reasignacion_gui
 from gestorcompras.gui import despacho_gui
 from gestorcompras.gui import seguimientos_gui
+from gestorcompras.utils import test_email_connection
 
 # Palette
 bg_base = "#F0F4F8"
@@ -35,15 +35,6 @@ def center_window(win: tk.Tk | tk.Toplevel):
     x = (win.winfo_screenwidth() // 2) - (w // 2)
     y = (win.winfo_screenheight() // 2) - (h // 2)
     win.geometry(f"{w}x{h}+{x}+{y}")
-
-def test_email_connection(email_address, email_password):
-    try:
-        with smtplib.SMTP("smtp.telconet.ec", 587) as server:
-            server.starttls()
-            server.login(email_address, email_password)
-        return True
-    except Exception:
-        return False
 
 def init_styles():
     style = ttk.Style()

--- a/GestorCompras_/gestorcompras/utils.py
+++ b/GestorCompras_/gestorcompras/utils.py
@@ -1,0 +1,12 @@
+import smtplib
+
+
+def test_email_connection(email_address: str, email_password: str) -> bool:
+    """Verify credentials against the Telconet SMTP server."""
+    try:
+        with smtplib.SMTP("smtp.telconet.ec", 587) as server:
+            server.starttls()
+            server.login(email_address, email_password)
+        return True
+    except Exception:
+        return False

--- a/GestorCompras_/gestorcompras/webapp/__init__.py
+++ b/GestorCompras_/gestorcompras/webapp/__init__.py
@@ -1,0 +1,53 @@
+import os
+from flask import Flask, render_template, request, redirect, url_for, session, flash
+from gestorcompras.utils import test_email_connection
+from gestorcompras.logic import despacho_logic
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.secret_key = os.environ.get("SECRET_KEY", "dev-secret")
+
+    @app.route('/', methods=['GET', 'POST'])
+    def login():
+        if request.method == 'POST':
+            user = request.form.get('username', '').strip()
+            password = request.form.get('password', '').strip()
+            if not user or not password:
+                flash('Debe ingresar usuario y contraseña.', 'danger')
+            else:
+                email = f"{user}@telconet.ec"
+                if test_email_connection(email, password):
+                    session['email'] = email
+                    session['password'] = password
+                    flash('Inicio de sesión correcto.', 'success')
+                    return redirect(url_for('menu'))
+                flash('Usuario o contraseña incorrectos.', 'danger')
+        return render_template('login.html')
+
+    @app.route('/menu')
+    def menu():
+        if 'email' not in session:
+            return redirect(url_for('login'))
+        return render_template('menu.html')
+
+    @app.route('/despacho', methods=['GET', 'POST'])
+    def despacho():
+        if 'email' not in session:
+            return redirect(url_for('login'))
+        result = None
+        if request.method == 'POST':
+            orden = request.form.get('orden', '').strip()
+            include_pdf = bool(request.form.get('include_pdf'))
+            template = request.form.get('template') or None
+            email_session = {'address': session['email'], 'password': session['password']}
+            result = despacho_logic.process_order(email_session, orden, include_pdf, template)
+        return render_template('despacho.html', result=result)
+
+    @app.route('/logout')
+    def logout():
+        session.clear()
+        flash('Sesión cerrada.', 'info')
+        return redirect(url_for('login'))
+
+    return app

--- a/GestorCompras_/gestorcompras/webapp/__init__.py
+++ b/GestorCompras_/gestorcompras/webapp/__init__.py
@@ -1,7 +1,12 @@
 import os
+import subprocess
+import sys
+from pathlib import Path
 from flask import Flask, render_template, request, redirect, url_for, session, flash
 from gestorcompras.utils import test_email_connection
 from gestorcompras.logic import despacho_logic
+from gestorcompras.services import db, google_sheets
+from gestorcompras.webapp import reasignacion
 
 
 def create_app() -> Flask:
@@ -36,11 +41,27 @@ def create_app() -> Flask:
             return redirect(url_for('login'))
         return None
 
-    @app.route('/reasignacion')
+    @app.route('/reasignacion', methods=['GET', 'POST'])
     def reasignacion():
         if (r := _ensure_login()) is not None:
             return r
-        return render_template('placeholder.html', title='Reasignación de Tareas')
+        msg = None
+        if request.method == 'POST':
+            if 'load' in request.form:
+                date = request.form.get('date') or ''
+                count, msg = reasignacion.load_tasks_from_email(
+                    session['email'], session['password'], date
+                )
+            elif 'process' in request.form:
+                task_id = int(request.form.get('task_id'))
+                task = next((t for t in db.get_tasks_temp() if t['id'] == task_id), None)
+                if task:
+                    msg = reasignacion.process_task_web(
+                        session['email'], session['password'], task
+                    )
+                    db.delete_task_temp(task_id)
+        tasks = db.get_tasks_temp()
+        return render_template('reasignacion.html', tasks=tasks, message=msg)
 
     @app.route('/despacho', methods=['GET', 'POST'])
     def despacho():
@@ -55,17 +76,48 @@ def create_app() -> Flask:
             result = despacho_logic.process_order(email_session, orden, include_pdf, template)
         return render_template('despacho.html', result=result)
 
-    @app.route('/seguimientos')
+    @app.route('/seguimientos', methods=['GET', 'POST'])
     def seguimientos():
         if (r := _ensure_login()) is not None:
             return r
-        return render_template('placeholder.html', title='Seguimientos')
+        msg = None
+        creds = db.get_config("GOOGLE_CREDS", "")
+        sid = db.get_config("GOOGLE_SHEET_ID", "")
+        sname = db.get_config("GOOGLE_SHEET_NAME", "")
+        orders = []
+        if creds and sid and sname:
+            try:
+                orders = google_sheets.read_report(creds, sid, sname)
+            except Exception as e:
+                msg = str(e)
+        else:
+            msg = "Debe configurar Google Sheets."
+        templates = [tpl[1] for tpl in db.get_email_templates()]
+        if request.method == 'POST':
+            selected = request.form.getlist('orders')
+            template = request.form.get('template') or None
+            attach = bool(request.form.get('attach_pdf'))
+            email_session = {'address': session['email'], 'password': session['password']}
+            logs = []
+            for oc in selected:
+                res = despacho_logic.process_order(
+                    email_session, oc, include_pdf=attach,
+                    template_name=template, cc_key='EMAIL_CC_SEGUIMIENTO'
+                )
+                logs.append(res)
+            msg = "\n".join(logs) if logs else "No se seleccionaron órdenes"
+        return render_template('seguimientos.html', orders=orders, templates=templates, message=msg)
 
-    @app.route('/descargas_oc')
+    @app.route('/descargas_oc', methods=['GET', 'POST'])
     def descargas_oc():
         if (r := _ensure_login()) is not None:
             return r
-        return render_template('placeholder.html', title='Descargas OC')
+        msg = None
+        if request.method == 'POST':
+            script = Path(__file__).resolve().parents[2] / 'DescargasOC-main' / 'descargas_oc' / 'ui.py'
+            subprocess.Popen([sys.executable, str(script)])
+            msg = 'Proceso iniciado en segundo plano.'
+        return render_template('descargas.html', message=msg)
 
     @app.route('/cotizador')
     def cotizador():
@@ -73,11 +125,30 @@ def create_app() -> Flask:
             return r
         return render_template('placeholder.html', title='Cotizador')
 
-    @app.route('/configuracion')
+    @app.route('/configuracion', methods=['GET', 'POST'])
     def configuracion():
         if (r := _ensure_login()) is not None:
             return r
-        return render_template('placeholder.html', title='Configuración')
+        msg = None
+        if request.method == 'POST':
+            if 'add_supplier' in request.form:
+                name = request.form.get('name')
+                ruc = request.form.get('ruc')
+                email_sup = request.form.get('email')
+                email_alt = request.form.get('email_alt') or None
+                if name and ruc and email_sup:
+                    db.add_supplier(name, ruc, email_sup, email_alt)
+                    msg = 'Proveedor agregado'
+            elif 'add_assignment' in request.form:
+                sub = request.form.get('subdept')
+                dept = request.form.get('dept')
+                person = request.form.get('person')
+                if sub and dept and person:
+                    db.set_assignment_config(sub, dept, person)
+                    msg = 'Asignación guardada'
+        suppliers = db.get_suppliers()
+        assignments = db.get_assignments()
+        return render_template('configuracion.html', suppliers=suppliers, assignments=assignments, message=msg)
 
     @app.route('/logout')
     def logout():

--- a/GestorCompras_/gestorcompras/webapp/__init__.py
+++ b/GestorCompras_/gestorcompras/webapp/__init__.py
@@ -31,10 +31,21 @@ def create_app() -> Flask:
             return redirect(url_for('login'))
         return render_template('menu.html')
 
-    @app.route('/despacho', methods=['GET', 'POST'])
-    def despacho():
+    def _ensure_login():
         if 'email' not in session:
             return redirect(url_for('login'))
+        return None
+
+    @app.route('/reasignacion')
+    def reasignacion():
+        if (r := _ensure_login()) is not None:
+            return r
+        return render_template('placeholder.html', title='Reasignación de Tareas')
+
+    @app.route('/despacho', methods=['GET', 'POST'])
+    def despacho():
+        if (r := _ensure_login()) is not None:
+            return r
         result = None
         if request.method == 'POST':
             orden = request.form.get('orden', '').strip()
@@ -43,6 +54,30 @@ def create_app() -> Flask:
             email_session = {'address': session['email'], 'password': session['password']}
             result = despacho_logic.process_order(email_session, orden, include_pdf, template)
         return render_template('despacho.html', result=result)
+
+    @app.route('/seguimientos')
+    def seguimientos():
+        if (r := _ensure_login()) is not None:
+            return r
+        return render_template('placeholder.html', title='Seguimientos')
+
+    @app.route('/descargas_oc')
+    def descargas_oc():
+        if (r := _ensure_login()) is not None:
+            return r
+        return render_template('placeholder.html', title='Descargas OC')
+
+    @app.route('/cotizador')
+    def cotizador():
+        if (r := _ensure_login()) is not None:
+            return r
+        return render_template('placeholder.html', title='Cotizador')
+
+    @app.route('/configuracion')
+    def configuracion():
+        if (r := _ensure_login()) is not None:
+            return r
+        return render_template('placeholder.html', title='Configuración')
 
     @app.route('/logout')
     def logout():

--- a/GestorCompras_/gestorcompras/webapp/reasignacion.py
+++ b/GestorCompras_/gestorcompras/webapp/reasignacion.py
@@ -1,0 +1,150 @@
+import datetime
+import imaplib
+import email
+import re
+import time
+import logging
+from typing import Tuple
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+from gestorcompras.services import db
+
+logger = logging.getLogger(__name__)
+
+
+def process_body(body: str):
+    task_pattern = r'Tarea:\s+(\d+)\s+Reasignación a:\s+(.*?)\s+Datos relacionados:(.*?)\n(?=Tarea:|\Z)'
+    tasks = re.findall(task_pattern, body, re.DOTALL)
+    tasks_data = []
+    for task_number, reasignacion, details in tasks:
+        detail_pattern = r'- OC (\d+) \| (.*?) \| FAC\. (\S+) \| INGR\. (\S+)'
+        details_list = re.findall(detail_pattern, details)
+        task_info = {
+            "task_number": task_number,
+            "reasignacion": reasignacion,
+            "details": [
+                {"OC": oc, "Proveedor": supplier, "Factura": invoice, "Ingreso": ingreso}
+                for oc, supplier, invoice, ingreso in details_list
+            ],
+        }
+        tasks_data.append(task_info)
+    return tasks_data
+
+
+def load_tasks_from_email(email_address: str, email_password: str, date_input: str) -> Tuple[int, str]:
+    """Carga tareas desde el correo y las guarda en la base de datos.
+    Retorna (cantidad, mensaje)."""
+    try:
+        date_since = datetime.datetime.strptime(date_input, "%d/%m/%Y").strftime("%d-%b-%Y")
+    except Exception:
+        return 0, "Formato de fecha inválido. Use DD/MM/YYYY"
+
+    imap_url = 'pop.telconet.ec'
+    try:
+        mail = imaplib.IMAP4_SSL(imap_url, 993)
+        mail.login(email_address, email_password)
+        mail.select("inbox")
+    except Exception as e:
+        return 0, f"Error de autenticación en correo: {e}"
+
+    query = f'(FROM "omar777j@gmail.com" SINCE "{date_since}")'
+    status, messages = mail.search(None, query)
+    messages = messages[0].split()
+    if not messages:
+        mail.logout()
+        return 0, f"No se encontraron correos desde {date_input}."
+
+    loaded_count = 0
+    for mail_id in messages:
+        status, data = mail.fetch(mail_id, '(RFC822)')
+        for response_part in data:
+            if isinstance(response_part, tuple):
+                try:
+                    msg = email.message_from_bytes(response_part[1])
+                    body = msg.get_payload(decode=True).decode()
+                except Exception:
+                    continue
+                tasks_data = process_body(body)
+                for task_info in tasks_data:
+                    inserted = db.insert_task_temp(task_info["task_number"],
+                                                   task_info["reasignacion"],
+                                                   task_info["details"])
+                    if inserted:
+                        loaded_count += 1
+    mail.logout()
+    return loaded_count, f"Se cargaron {loaded_count} tareas (sin duplicados)."
+
+
+def login_telcos(driver, username, password):
+    driver.get('https://telcos.telconet.ec/inicio/?josso_back_to=http://telcos.telconet.ec/check&josso_partnerapp_host=telcos.telconet.ec')
+    user_input = WebDriverWait(driver, 20).until(EC.element_to_be_clickable((By.NAME, 'josso_username')))
+    user_input.send_keys(username)
+    password_input = WebDriverWait(driver, 20).until(EC.element_to_be_clickable((By.NAME, 'josso_password')))
+    password_input.send_keys(password)
+    password_input.send_keys(Keys.RETURN)
+    WebDriverWait(driver, 20).until(EC.presence_of_element_located((By.ID, 'spanTareasPersonales')))
+
+
+def wait_clickable_or_error(driver, locator, description, timeout=30, retries=3):
+    for intento in range(retries):
+        try:
+            return WebDriverWait(driver, timeout).until(EC.element_to_be_clickable(locator))
+        except Exception as e:
+            if intento == retries - 1:
+                raise Exception(f"No se pudo encontrar {description}") from e
+            time.sleep(1)
+
+
+def process_task(driver, task):
+    task_number = task["task_number"]
+    dept = task["reasignacion"].strip().upper()
+    assignments = db.get_assignment_config()
+    empleado = assignments.get(dept, {}).get("person", "SIN ASIGNAR")
+    dept_name = assignments.get(dept, {}).get("department", "")
+
+    element = wait_clickable_or_error(driver, (By.ID, 'spanTareasPersonales'), 'el menú de tareas')
+    driver.execute_script("arguments[0].click();", element)
+
+    search_input = wait_clickable_or_error(driver, (By.CSS_SELECTOR, 'input[type="search"].form-control.form-control-sm'), 'el campo de búsqueda')
+    search_input.clear()
+    search_input.send_keys(task_number)
+    search_input.send_keys(Keys.RETURN)
+
+    time.sleep(1)
+    try:
+        wait_clickable_or_error(driver, (By.CSS_SELECTOR, 'span.glyphicon.glyphicon-step-forward'), 'el botón para abrir la tarea').click()
+    except Exception:
+        raise Exception(f"No se encontraron las tareas en la plataforma Telcos.\nTarea: {task_number}")
+
+    time.sleep(1)
+    comment_input = wait_clickable_or_error(driver, (By.ID, 'txtareaComentario'), 'el campo de comentarios')
+    comment_input.clear()
+    comment_input.send_keys(f"Departamento: {dept_name}\nEmpleado: {empleado}")
+
+    submit_btn = wait_clickable_or_error(driver, (By.ID, 'btnGuardarAsignacion'), 'el botón de guardar')
+    submit_btn.click()
+    time.sleep(1)
+
+
+def process_task_web(email_addr, email_pwd, task):
+    options = Options()
+    options.add_argument('--headless')
+    options.add_argument('--no-sandbox')
+    options.add_argument('--disable-dev-shm-usage')
+    driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
+    try:
+        login_telcos(driver, email_addr, email_pwd)
+        process_task(driver, task)
+        return f"Tarea {task['task_number']} procesada"
+    except Exception as e:
+        return f"Error en tarea {task['task_number']}: {e}"
+    finally:
+        driver.quit()

--- a/GestorCompras_/gestorcompras/webapp/templates/base.html
+++ b/GestorCompras_/gestorcompras/webapp/templates/base.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <title>Gestor de Compras</title>
+  </head>
+  <body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('menu') }}">GestorCompras</a>
+        {% if session.get('email') %}
+        <span class="navbar-text ms-auto me-3">{{ session['email'] }}</span>
+        <a class="btn btn-sm btn-outline-light" href="{{ url_for('logout') }}">Salir</a>
+        {% endif %}
+      </div>
+    </nav>
+    <main class="container">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+          <div class="alert alert-{{ category }}">{{ message }}</div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/GestorCompras_/gestorcompras/webapp/templates/configuracion.html
+++ b/GestorCompras_/gestorcompras/webapp/templates/configuracion.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Configuración</h2>
+{% if message %}<div class="alert alert-info">{{ message }}</div>{% endif %}
+<div class="row">
+  <div class="col-md-6">
+    <h4>Proveedores</h4>
+    <form method="post" class="row g-2 mb-3">
+      <input type="hidden" name="add_supplier" value="1">
+      <div class="col-6"><input name="name" class="form-control" placeholder="Nombre"></div>
+      <div class="col-6"><input name="ruc" class="form-control" placeholder="RUC"></div>
+      <div class="col-6"><input name="email" class="form-control" placeholder="Correo"></div>
+      <div class="col-6"><input name="email_alt" class="form-control" placeholder="Correo alt"></div>
+      <div class="col-12"><button class="btn btn-sm btn-primary">Agregar</button></div>
+    </form>
+    <table class="table table-sm table-striped">
+      <thead><tr><th>Nombre</th><th>RUC</th><th>Email</th></tr></thead>
+      <tbody>
+      {% for s in suppliers %}
+        <tr><td>{{ s[1] }}</td><td>{{ s[2] }}</td><td>{{ s[3] }}</td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <div class="col-md-6">
+    <h4>Asignación</h4>
+    <form method="post" class="row g-2 mb-3">
+      <input type="hidden" name="add_assignment" value="1">
+      <div class="col-4"><input name="subdept" class="form-control" placeholder="Subdepto"></div>
+      <div class="col-4"><input name="dept" class="form-control" placeholder="Departamento"></div>
+      <div class="col-4"><input name="person" class="form-control" placeholder="Persona"></div>
+      <div class="col-12"><button class="btn btn-sm btn-primary">Guardar</button></div>
+    </form>
+    <table class="table table-sm table-striped">
+      <thead><tr><th>Subdepto</th><th>Departamento</th><th>Persona</th></tr></thead>
+      <tbody>
+      {% for a in assignments %}
+        <tr><td>{{ a[0] }}</td><td>{{ a[1] }}</td><td>{{ a[2] }}</td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/GestorCompras_/gestorcompras/webapp/templates/descargas.html
+++ b/GestorCompras_/gestorcompras/webapp/templates/descargas.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Descargas OC</h2>
+{% if message %}<div class="alert alert-info">{{ message }}</div>{% endif %}
+<form method="post">
+  <button class="btn btn-primary">Iniciar Descarga</button>
+</form>
+{% endblock %}

--- a/GestorCompras_/gestorcompras/webapp/templates/despacho.html
+++ b/GestorCompras_/gestorcompras/webapp/templates/despacho.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Solicitud de Despachos</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Número de Orden</label>
+    <input class="form-control" type="text" name="orden" required>
+  </div>
+  <div class="mb-3 form-check">
+    <input class="form-check-input" type="checkbox" name="include_pdf" id="pdfCheck" checked>
+    <label class="form-check-label" for="pdfCheck">Adjuntar PDF</label>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Formato de correo (opcional)</label>
+    <input class="form-control" type="text" name="template" placeholder="FORMATO">
+  </div>
+  <button class="btn btn-primary" type="submit">Enviar</button>
+</form>
+{% if result %}
+<div class="alert alert-info mt-3">{{ result }}</div>
+{% endif %}
+{% endblock %}

--- a/GestorCompras_/gestorcompras/webapp/templates/login.html
+++ b/GestorCompras_/gestorcompras/webapp/templates/login.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-4">
+    <h2>Inicio de sesión</h2>
+    <form method="post">
+      <div class="mb-3">
+        <label class="form-label">Usuario Telcos</label>
+        <input class="form-control" type="text" name="username" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Contraseña</label>
+        <input class="form-control" type="password" name="password" required>
+      </div>
+      <button class="btn btn-primary" type="submit">Entrar</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/GestorCompras_/gestorcompras/webapp/templates/menu.html
+++ b/GestorCompras_/gestorcompras/webapp/templates/menu.html
@@ -2,6 +2,11 @@
 {% block content %}
 <h2>Menú principal</h2>
 <ul class="list-group">
+  <li class="list-group-item"><a href="{{ url_for('reasignacion') }}">Reasignación de Tareas</a></li>
   <li class="list-group-item"><a href="{{ url_for('despacho') }}">Solicitud de Despachos</a></li>
+  <li class="list-group-item"><a href="{{ url_for('seguimientos') }}">Seguimientos</a></li>
+  <li class="list-group-item"><a href="{{ url_for('descargas_oc') }}">Descargas OC</a></li>
+  <li class="list-group-item"><a href="{{ url_for('cotizador') }}">Cotizador</a></li>
+  <li class="list-group-item"><a href="{{ url_for('configuracion') }}">Configuración</a></li>
 </ul>
 {% endblock %}

--- a/GestorCompras_/gestorcompras/webapp/templates/menu.html
+++ b/GestorCompras_/gestorcompras/webapp/templates/menu.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Menú principal</h2>
+<ul class="list-group">
+  <li class="list-group-item"><a href="{{ url_for('despacho') }}">Solicitud de Despachos</a></li>
+</ul>
+{% endblock %}

--- a/GestorCompras_/gestorcompras/webapp/templates/placeholder.html
+++ b/GestorCompras_/gestorcompras/webapp/templates/placeholder.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ title }}</h2>
+<p>Esta opción se encuentra en desarrollo.</p>
+<p><a href="{{ url_for('menu') }}" class="btn btn-secondary">Volver al menú</a></p>
+{% endblock %}

--- a/GestorCompras_/gestorcompras/webapp/templates/reasignacion.html
+++ b/GestorCompras_/gestorcompras/webapp/templates/reasignacion.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Reasignación de Tareas</h2>
+{% if message %}<div class="alert alert-info">{{ message }}</div>{% endif %}
+<form method="post" class="row g-3 mb-3">
+  <div class="col-auto">
+    <input type="text" name="date" class="form-control" placeholder="DD/MM/YYYY">
+  </div>
+  <div class="col-auto">
+    <button type="submit" name="load" class="btn btn-primary">Cargar tareas</button>
+  </div>
+</form>
+{% if tasks %}
+<table class="table table-striped">
+  <thead><tr><th>Tarea</th><th>Reasignación</th><th></th></tr></thead>
+  <tbody>
+    {% for t in tasks %}
+    <tr>
+      <td>{{ t.task_number }}</td>
+      <td>{{ t.reasignacion }}</td>
+      <td>
+        <form method="post">
+          <input type="hidden" name="task_id" value="{{ t.id }}">
+          <button name="process" class="btn btn-sm btn-success">Procesar</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No hay tareas cargadas.</p>
+{% endif %}
+{% endblock %}

--- a/GestorCompras_/gestorcompras/webapp/templates/seguimientos.html
+++ b/GestorCompras_/gestorcompras/webapp/templates/seguimientos.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Seguimientos</h2>
+{% if message %}<div class="alert alert-info">{{ message }}</div>{% endif %}
+{% if orders %}
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Formato de correo</label>
+    <select name="template" class="form-select">
+      {% for t in templates %}
+      <option value="{{ t }}">{{ t }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" name="attach_pdf" id="attach_pdf" checked>
+    <label class="form-check-label" for="attach_pdf">Adjuntar PDF</label>
+  </div>
+  <table class="table table-striped">
+    <thead><tr><th></th><th>OC</th><th>Proveedor</th><th>Tarea</th></tr></thead>
+    <tbody>
+      {% for r in orders %}
+      <tr>
+        <td><input type="checkbox" name="orders" value="{{ r['Orden de Compra'] }}"></td>
+        <td>{{ r['Orden de Compra'] }}</td>
+        <td>{{ r['Proveedor'] }}</td>
+        <td>{{ r['Tarea'] }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <button class="btn btn-primary" type="submit">Enviar Correos</button>
+</form>
+{% else %}
+<p>No se encontraron órdenes.</p>
+{% endif %}
+{% endblock %}

--- a/implementacion_web.txt
+++ b/implementacion_web.txt
@@ -1,0 +1,20 @@
+Implementación web del Gestor de Compras
+=======================================
+
+Pruebas locales
+---------------
+1. Crear un entorno virtual y activarlo.
+2. Instalar dependencias: `pip install -r requirements.txt`.
+3. Ejecutar la aplicación con `python run_web.py`.
+4. Abrir `http://localhost:5000` en el navegador y realizar inicio de sesión.
+
+Despliegue gratuito en Render
+-----------------------------
+1. Subir este repositorio a GitHub.
+2. Crear una cuenta gratuita en https://render.com.
+3. Crear un **New Web Service** enlazando el repositorio.
+4. Build Command: `pip install -r requirements.txt`.
+5. Start Command: `gunicorn run_web:app`.
+6. Añadir la variable de entorno `SECRET_KEY` con un valor seguro.
+7. Presionar **Create Web Service** y esperar a que finalice el despliegue.
+8. Probar la aplicación utilizando la URL pública que entrega Render.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
 jinja2
 pdfplumber
-pandas 
+pandas
 openpyxl
-selenium 
+selenium
 
 webdriver_manager
 gspread
 google-auth
 
+Flask
+gunicorn
 
 

--- a/run_web.py
+++ b/run_web.py
@@ -1,0 +1,6 @@
+from gestorcompras.webapp import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)


### PR DESCRIPTION
## Summary
- expose SMTP login check via shared utility
- add Flask web interface with login and despacho order processing
- document deployment steps for free Render hosting

## Testing
- `pip install requests_mock` *(fails: Could not find a version that satisfies the requirement requests_mock)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests_mock')*


------
https://chatgpt.com/codex/tasks/task_e_68c6235098e08320a4b20d62174ed775