### PR TITLE
feat: add dark theme and resource monitor

### DIFF
--- a/GestorCompras_/gestorcompras/gui/seguimientos_gui.py
+++ b/GestorCompras_/gestorcompras/gui/seguimientos_gui.py
@@ -5,7 +5,7 @@ from tkinter.scrolledtext import ScrolledText
 from gestorcompras.services import db
 from gestorcompras.services import google_sheets
 from gestorcompras.logic import despacho_logic
-from gestorcompras.theme import color_blanco, color_borde
+from gestorcompras.theme import color_blanco, color_borde, color_texto, bg_frame
 
 
 def center_window(win: tk.Tk | tk.Toplevel):
@@ -61,7 +61,7 @@ def open_seguimientos(master, email_session):
     scrollbar.pack(side="right", fill="y")
 
     ttk.Label(frame, text="Estado del Proceso:", style="MyLabel.TLabel").grid(row=5, column=0, sticky="w")
-    log_box = ScrolledText(frame, height=6, state="disabled")
+    log_box = ScrolledText(frame, height=6, state="disabled", bg=bg_frame, fg=color_texto)
     log_box.grid(row=6, column=0, sticky="nsew", pady=5)
 
     ttk.Label(frame, text="Formato de correo:", style="MyLabel.TLabel").grid(row=4, column=0, sticky="w")

--- a/GestorCompras_/gestorcompras/gui/status_bar.py
+++ b/GestorCompras_/gestorcompras/gui/status_bar.py
@@ -1,0 +1,18 @@
+from tkinter import ttk
+import psutil
+
+class ResourceStatusBar(ttk.Frame):
+    """Simple status bar displaying CPU and memory usage."""
+    def __init__(self, master, update_ms: int = 1000):
+        super().__init__(master, style="MyFrame.TFrame")
+        self.update_ms = update_ms
+        self.label = ttk.Label(self, text="", style="MyLabel.TLabel")
+        self.label.pack(side="right", padx=5)
+        self._update_stats()
+
+    def _update_stats(self):
+        process = psutil.Process()
+        mem = process.memory_info().rss / (1024 * 1024)
+        cpu = psutil.cpu_percent(interval=None)
+        self.label.configure(text=f"CPU: {cpu:.1f}%  MEM: {mem:.1f} MB")
+        self.after(self.update_ms, self._update_stats)

--- a/GestorCompras_/gestorcompras/main.py
+++ b/GestorCompras_/gestorcompras/main.py
@@ -9,6 +9,7 @@ from gestorcompras.gui import config_gui
 from gestorcompras.gui import reasignacion_gui
 from gestorcompras.gui import despacho_gui
 from gestorcompras.gui import seguimientos_gui
+from gestorcompras.gui.status_bar import ResourceStatusBar
 from gestorcompras import theme
 
 # Palette (imported from theme for a cohesive modern look)
@@ -19,7 +20,6 @@ color_hover = theme.color_hover
 color_acento = theme.color_acento
 color_texto = theme.color_texto
 color_titulos = theme.color_titulos
-color_blanco = theme.color_blanco
 color_borde = theme.color_borde
 
 # Fonts
@@ -71,7 +71,7 @@ def init_styles():
     style.configure(
         "MyButton.TButton",
         font=fuente_bold,
-        foreground=color_blanco,
+        foreground=color_texto,
         background=color_primario,
         padding=10,
         relief="raised",
@@ -80,7 +80,7 @@ def init_styles():
     style.configure(
         "MyButtonHover.TButton",
         font=fuente_bold,
-        foreground=color_blanco,
+        foreground=color_texto,
         background=color_hover,
         padding=12,
         relief="raised",
@@ -97,27 +97,38 @@ def init_styles():
         padding=5,
         relief="solid",
         borderwidth=1,
+        foreground=color_texto,
+        fieldbackground=bg_base,
+        background=bg_base,
+        insertcolor=color_texto,
+    )
+    style.configure(
+        "TCombobox",
+        foreground=color_texto,
+        fieldbackground=bg_base,
+        background=bg_base,
+        arrowcolor=color_texto,
     )
     style.configure("MyNotebook.TNotebook", background=bg_base, borderwidth=0)
     style.configure("MyNotebook.TNotebook.Tab", padding=[12, 8], font=fuente_bold)
     style.map("MyNotebook.TNotebook.Tab",
               background=[("selected", color_primario),
                           ("active", color_hover)],
-              foreground=[("selected", color_blanco),
-                          ("active", color_blanco)])
+              foreground=[("selected", color_texto),
+                          ("active", color_texto)])
     style.configure(
         "MyTreeview.Treeview",
-        background=color_blanco,
+        background=bg_frame,
         foreground=color_texto,
         rowheight=28,
-        fieldbackground="#F7F9FB",
+        fieldbackground=bg_frame,
         font=fuente_normal,
     )
-    style.configure("MyTreeview.Treeview.Heading", background=color_primario, foreground=color_blanco, font=fuente_bold)
+    style.configure("MyTreeview.Treeview.Heading", background=color_primario, foreground=color_titulos, font=fuente_bold)
     style.map("MyTreeview.Treeview.Heading", background=[("active", color_hover)])
     style.configure("MyVertical.TScrollbar", gripcount=0, background=color_primario, troughcolor=bg_frame,
-                    bordercolor=bg_frame, arrowcolor=color_blanco)
-    style.map("MyVertical.TScrollbar", background=[("active", color_hover)], arrowcolor=[("active", color_blanco)])
+                    bordercolor=bg_frame, arrowcolor=color_texto)
+    style.map("MyVertical.TScrollbar", background=[("active", color_hover)], arrowcolor=[("active", color_texto)])
     style.configure("MyLabelFrame.TLabelframe", background=bg_frame, relief="groove")
     style.configure("MyLabelFrame.TLabelframe.Label", background=bg_frame, foreground=color_texto, font=fuente_bold)
     style.configure("Banner.TLabel", background=bg_frame, foreground=color_titulos, font=fuente_banner)
@@ -347,6 +358,9 @@ def main():
     
     container = ttk.Frame(root, style="MyFrame.TFrame")
     container.pack(fill="both", expand=True)
+
+    status_bar = ResourceStatusBar(root)
+    status_bar.pack(side="bottom", fill="x")
     
     def show_main_menu():
         for widget in container.winfo_children():

--- a/GestorCompras_/gestorcompras/theme.py
+++ b/GestorCompras_/gestorcompras/theme.py
@@ -1,13 +1,13 @@
 # Centralized theme configuration for GestorCompras UI
 
 # Palette
-bg_base = "#E5E7EB"  # soft gray for main window background
-bg_frame = "#F3F4F6"  # lighter gray for frames
+bg_base = "#111827"  # deep gray for main window background
+bg_frame = "#1F2937"  # slightly lighter gray for frames
 color_primario = "#3B82F6"  # vibrant blue
 color_hover = "#2563EB"     # darker blue for hover state
 color_acento = "#F59E0B"    # accent amber for highlights
-color_texto = "#1F2937"      # dark gray for body text
-color_titulos = "#111827"    # almost black for titles
-color_blanco = "#FFFFFF"
-color_borde = "#E5E7EB"      # subtle border gray
+color_texto = "#F3F4F6"      # light gray for body text
+color_titulos = "#F9FAFB"    # near white for titles
+color_blanco = "#1F2937"     # dark background substitute
+color_borde = "#374151"      # dark border gray
 

--- a/GestorCompras_/requirements.txt
+++ b/GestorCompras_/requirements.txt
@@ -2,5 +2,6 @@ jinja2
 pdfplumber
 pandas 
 openpyxl
-selenium 
+selenium
 webdriver_manager
+psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,13 @@ jinja2
 pdfplumber
 pandas 
 openpyxl
-selenium 
+selenium
 
 webdriver_manager
 gspread
 google-auth
+
+psutil
 
 
 


### PR DESCRIPTION
## Summary
- switch UI palette to dark theme
- add psutil-powered status bar for CPU/memory usage
- style widgets for consistency with new theme

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement psutil)*
- `pip install requests_mock` *(fails: Could not find a version that satisfies the requirement requests_mock)*
- `pytest` *(fails: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_e_68c73d2cfe808320912cd192c1ddf75c