### PR TITLE
Fix Abastecimiento UI launch in Descargas OC module

### DIFF
--- a/DescargasOC-main/descargas_oc/ui_abastecimiento.py
+++ b/DescargasOC-main/descargas_oc/ui_abastecimiento.py
@@ -15,6 +15,9 @@ except ImportError:  # pragma: no cover
 
 lock = threading.Lock()
 
+# Valor por defecto para el campo "Solicitante"
+DEFAULT_SOLICITANTE = "1221 - HERRERA PUENTE WILLIAM"
+
 
 def ejecutar(entry_fd, entry_fh, entry_sol, entry_aut, btn):
     if not lock.acquire(blocking=False):
@@ -63,11 +66,14 @@ def main():
 
     cfg = Config()
     tk.Label(root, text="Solicitante:").grid(row=2, column=0, sticky="e")
-    sol_var = tk.StringVar()
+    solicitantes = cfg.abastecimiento_solicitantes or []
+    if DEFAULT_SOLICITANTE not in solicitantes:
+        solicitantes.insert(0, DEFAULT_SOLICITANTE)
+    sol_var = tk.StringVar(value=DEFAULT_SOLICITANTE)
     entry_sol = ttk.Combobox(
         root,
         textvariable=sol_var,
-        values=cfg.abastecimiento_solicitantes or [],
+        values=solicitantes,
         width=40,
     )
     entry_sol.grid(row=2, column=1, padx=5, pady=2)
@@ -109,7 +115,11 @@ def main():
         configurar_abastecimiento()
         nuevo = Config()
         if entry_sol.winfo_exists():
-            entry_sol['values'] = nuevo.abastecimiento_solicitantes or []
+            solicitantes = nuevo.abastecimiento_solicitantes or []
+            if DEFAULT_SOLICITANTE not in solicitantes:
+                solicitantes.insert(0, DEFAULT_SOLICITANTE)
+            entry_sol['values'] = solicitantes
+            sol_var.set(DEFAULT_SOLICITANTE)
         if entry_aut.winfo_exists():
             entry_aut['values'] = nuevo.abastecimiento_autorizadores or []
 

--- a/DescargasOC-main/descargas_oc/ui_abastecimiento.py
+++ b/DescargasOC-main/descargas_oc/ui_abastecimiento.py
@@ -82,21 +82,39 @@ def main():
     )
     entry_aut.grid(row=3, column=1, padx=5, pady=2)
 
+    var_visible = tk.BooleanVar(value=not bool(cfg.headless))
+
+    def actualizar_visible():
+        cfg.load()
+        cfg.data["headless"] = not var_visible.get()
+        cfg.save()
+
+    chk_visible = tk.Checkbutton(
+        root,
+        text="Descarga visible",
+        variable=var_visible,
+        command=actualizar_visible,
+        selectcolor="#00aa00",
+    )
+    chk_visible.grid(row=4, column=1, sticky="w", padx=5, pady=2)
+
     btn_ejecutar = tk.Button(
         root,
         text="Descargar",
         command=lambda: ejecutar(entry_fd, entry_fh, entry_sol, entry_aut, btn_ejecutar),
     )
-    btn_ejecutar.grid(row=4, column=0, columnspan=2, pady=10)
+    btn_ejecutar.grid(row=5, column=0, columnspan=2, pady=10)
 
     def abrir_config():
         configurar_abastecimiento()
         nuevo = Config()
-        entry_sol['values'] = nuevo.abastecimiento_solicitantes or []
-        entry_aut['values'] = nuevo.abastecimiento_autorizadores or []
+        if entry_sol.winfo_exists():
+            entry_sol['values'] = nuevo.abastecimiento_solicitantes or []
+        if entry_aut.winfo_exists():
+            entry_aut['values'] = nuevo.abastecimiento_autorizadores or []
 
     btn_cfg = tk.Button(root, text="Configurar", command=abrir_config)
-    btn_cfg.grid(row=5, column=0, columnspan=2, pady=(0, 10))
+    btn_cfg.grid(row=6, column=0, columnspan=2, pady=(0, 10))
 
     def center_window(win):
         win.update_idletasks()

--- a/GestorCompras_/gestorcompras/main.py
+++ b/GestorCompras_/gestorcompras/main.py
@@ -281,35 +281,14 @@ class MainMenu(tk.Frame):
             option_win.destroy()
 
         def open_abastecimiento():
+            script = (
+                Path(__file__).resolve().parents[2]
+                / "DescargasOC-main"
+                / "descargas_oc"
+                / "ui_abastecimiento.py"
+            )
+            subprocess.Popen([sys.executable, str(script)])
             option_win.destroy()
-            win = tk.Toplevel(self.master)
-            win.title("Descarga Abastecimiento")
-            win.transient(self.master)
-            win.grab_set()
-            center_window(win)
-
-            frame = ttk.Frame(win, style="MyFrame.TFrame", padding=10)
-            frame.pack(fill="both", expand=True)
-
-            ttk.Label(frame, text="Fecha inicio:", style="MyLabel.TLabel").grid(
-                row=0, column=0, sticky="e", pady=5
-            )
-            ttk.Entry(frame, style="MyEntry.TEntry").grid(row=0, column=1, pady=5)
-            ttk.Label(frame, text="Fecha final:", style="MyLabel.TLabel").grid(
-                row=1, column=0, sticky="e", pady=5
-            )
-            ttk.Entry(frame, style="MyEntry.TEntry").grid(row=1, column=1, pady=5)
-
-            btn_desc = ttk.Button(
-                frame,
-                text="Descargar",
-                style="MyButton.TButton",
-                command=lambda: messagebox.showinfo(
-                    "Información", "Funcionalidad en desarrollo"
-                ),
-            )
-            btn_desc.grid(row=2, column=0, columnspan=2, pady=10)
-            add_hover_effect(btn_desc)
 
         option_win = tk.Toplevel(self.master)
         option_win.title("Descargas OC")


### PR DESCRIPTION
## Summary
- Launch real Abastecimiento UI instead of placeholder when selecting Abastecimiento in Descargas OC menu

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests_mock')*
- `pip install requests_mock` *(fails: Could not find a version that satisfies the requirement requests_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b3858c308320a284b51e8bca5e51