### PR TITLE
Preserve pending OC UIDLs and parse HTML provider names

### DIFF
--- a/DescargasOC-main/descargas_oc/selenium_abastecimiento.py
+++ b/DescargasOC-main/descargas_oc/selenium_abastecimiento.py
@@ -204,7 +204,7 @@ def descargar_abastecimiento(
 
     driver.quit()
 
-    subidos, faltantes = mover_oc(cfg, ordenes)
+    subidos, faltantes, _errores_mov = mover_oc(cfg, ordenes)
     enviar_reporte(
         subidos,
         faltantes,

--- a/DescargasOC-main/descargas_oc/selenium_modulo.py
+++ b/DescargasOC-main/descargas_oc/selenium_modulo.py
@@ -299,9 +299,10 @@ def descargar_oc(
         driver.quit()
 
     numeros = [oc.get("numero") for oc in ordenes]
-    subidos, faltantes = mover_oc(cfg, ordenes)
+    subidos, faltantes, errores_mov = mover_oc(cfg, ordenes)
     if getattr(cfg, "compra_bienes", False):
         organizar_bienes(cfg.carpeta_analizar, cfg.carpeta_analizar)
+    errores.extend(errores_mov)
     faltantes.extend(n for n in numeros if any(n in e for e in errores))
     # evitar números repetidos al reportar faltantes
     faltantes = list(dict.fromkeys(faltantes))

--- a/DescargasOC-main/descargas_oc/ui.py
+++ b/DescargasOC-main/descargas_oc/ui.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 import threading
 import logging
+import re
 from datetime import datetime
 from tkinter import messagebox
 
@@ -78,6 +79,17 @@ def realizar_escaneo(text_widget: tk.Text, lbl_last: tk.Label):
 
         append("Buscando órdenes...\n")
         ordenes, ultimo = buscar_ocs(cfg)
+        uidl_por_numero = {
+            o.get("numero"): o.get("uidl")
+            for o in ordenes
+            if o.get("numero") and o.get("uidl")
+        }
+        uidl_a_numeros: dict[str, set[str]] = {}
+        for numero, uidl in uidl_por_numero.items():
+            if not uidl:
+                continue
+            uidl_a_numeros.setdefault(uidl, set()).add(numero)
+        pendientes_uidls = set(uidl_a_numeros)
         exitosas: list[str] = []
         faltantes: list[str] = []
         errores: list[str] = []
@@ -93,15 +105,37 @@ def realizar_escaneo(text_widget: tk.Text, lbl_last: tk.Label):
                 subidos, no_encontrados = [], [o.get("numero") for o in ordenes]
             exitosas.extend(subidos)
             faltantes.extend(no_encontrados)
+            numeros_con_problemas = {str(n) for n in no_encontrados}
+            for error in errores:
+                m = re.search(r"OC\s*(\d+)", error)
+                if m:
+                    numeros_con_problemas.add(m.group(1))
+            uidls_con_problemas = {
+                uidl_por_numero[num]
+                for num in numeros_con_problemas
+                if num in uidl_por_numero and uidl_por_numero[num]
+            }
+            subidos_set = set(subidos)
+            uidls_exitosos: list[str] = []
+            for orden in ordenes:
+                uidl = orden.get("uidl")
+                if not uidl or uidl in uidls_con_problemas:
+                    continue
+                numeros_uidl = uidl_a_numeros.get(uidl, set())
+                if numeros_uidl and numeros_uidl.issubset(subidos_set) and uidl not in uidls_exitosos:
+                    uidls_exitosos.append(uidl)
+            pendientes_uidls -= set(uidls_exitosos)
             for num in subidos:
                 append(f"✔️ OC {num} procesada\n")
             for num in no_encontrados:
                 append(f"❌ OC {num} faltante\n")
+            if uidls_exitosos:
+                uidls_sin_duplicados = list(dict.fromkeys(uidls_exitosos))
+                ultimo_guardar = ultimo if not pendientes_uidls else None
+                registrar_procesados(uidls_sin_duplicados, ultimo_guardar)
         else:
             append("No se encontraron nuevas órdenes\n")
         enviado = enviar_reporte(exitosas, faltantes, ordenes, cfg)
-        if enviado:
-            registrar_procesados([o['uidl'] for o in ordenes], ultimo)
         if ordenes:
             if errores:
                 summary = "Errores durante la descarga:\n" + "\n".join(errores)

--- a/DescargasOC-main/tests/test_escuchador.py
+++ b/DescargasOC-main/tests/test_escuchador.py
@@ -1,0 +1,191 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from descargas_oc import escuchador  # noqa: E402
+
+
+def _setup_temp_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(escuchador, 'DATA_DIR', tmp_path)
+    monkeypatch.setattr(escuchador, 'PROCESADOS_FILE', tmp_path / 'procesados.txt')
+    monkeypatch.setattr(escuchador, 'LAST_UIDL_FILE', tmp_path / 'last_uidl.txt')
+    monkeypatch.setattr(escuchador, 'ORDENES_TMP', tmp_path / 'ordenes_tmp.json')
+
+
+class DummyPOP:
+    def __init__(self, uidl_value: str):
+        self.uidl_value = uidl_value
+
+    def user(self, _):
+        return b'+OK'
+
+    def pass_(self, _):
+        return b'+OK'
+
+    def uidl(self):
+        return b'+OK', [f'1 {self.uidl_value}'.encode()], None
+
+    def quit(self):
+        return b'+OK'
+
+
+@pytest.fixture
+def cfg():
+    return SimpleNamespace(
+        pop_server='server',
+        pop_port=995,
+        usuario='usuario@telconet.ec',
+        password='secreto',
+        batch_size=5,
+        max_threads=1,
+    )
+
+
+def test_valid_sender_without_data_not_marked_processed(tmp_path, monkeypatch, cfg):
+    _setup_temp_paths(tmp_path, monkeypatch)
+    uidl_value = 'UID123'
+
+    raw_email = (
+        'Subject: Aviso\r\n'
+        'From: "NAF" <naf@telconet.ec>\r\n'
+        '\r\n'
+        'Mensaje sin información de orden\r\n'
+    ).encode('utf-8')
+
+    monkeypatch.setattr(escuchador, '_descargar_mensaje', lambda num, c: (uidl_value, raw_email))
+
+    def fake_pop(server, port):  # noqa: ARG001 - firmas compatibles
+        return DummyPOP(uidl_value)
+
+    monkeypatch.setattr(escuchador.poplib, 'POP3_SSL', fake_pop)
+
+    ordenes, ultimo = escuchador.buscar_ocs(cfg)
+
+    assert ordenes == []
+    assert ultimo == uidl_value
+    assert not escuchador.PROCESADOS_FILE.exists()
+
+
+def test_valid_order_detected_from_default_sender(tmp_path, monkeypatch, cfg):
+    _setup_temp_paths(tmp_path, monkeypatch)
+    uidl_value = 'UID456'
+
+    raw_email = (
+        'Subject: SISTEMA NAF: Notificacion AUTORIZACION ORDEN COMPRA No 12345\r\n'
+        'From: Notificaciones NAF <naf@telconet.ec>\r\n'
+        '\r\n'
+        'Fecha Autorizacion: 05/06/2024\r\n'
+        'Fecha Orden: 06/06/2024\r\n'
+        'Proveedor Ejemplo\r\n'
+    ).encode('utf-8')
+
+    monkeypatch.setattr(escuchador, '_descargar_mensaje', lambda num, c: (uidl_value, raw_email))
+
+    def fake_pop(server, port):  # noqa: ARG001 - firmas compatibles
+        return DummyPOP(uidl_value)
+
+    monkeypatch.setattr(escuchador.poplib, 'POP3_SSL', fake_pop)
+
+    ordenes, ultimo = escuchador.buscar_ocs(cfg)
+
+    assert len(ordenes) == 1
+    assert ordenes[0]['numero'] == '12345'
+    assert ultimo == uidl_value
+    assert escuchador.ORDENES_TMP.exists()
+
+
+def test_invalid_sender_is_marked_processed(tmp_path, monkeypatch, cfg):
+    _setup_temp_paths(tmp_path, monkeypatch)
+    uidl_value = 'UID789'
+
+    raw_email = (
+        'Subject: SISTEMA NAF: Notificacion AUTORIZACION ORDEN COMPRA No 99999\r\n'
+        'From: Alerta <otro@dominio.com>\r\n'
+        '\r\n'
+        'Fecha Autorizacion: 01/02/2024\r\n'
+    ).encode('utf-8')
+
+    monkeypatch.setattr(escuchador, '_descargar_mensaje', lambda num, c: (uidl_value, raw_email))
+
+    def fake_pop(server, port):  # noqa: ARG001 - firmas compatibles
+        return DummyPOP(uidl_value)
+
+    monkeypatch.setattr(escuchador.poplib, 'POP3_SSL', fake_pop)
+
+    ordenes, _ = escuchador.buscar_ocs(cfg)
+
+    assert ordenes == []
+    assert escuchador.PROCESADOS_FILE.exists()
+    assert escuchador.PROCESADOS_FILE.read_text().strip() == uidl_value
+
+
+def test_additional_sender_from_config(tmp_path, monkeypatch, cfg):
+    _setup_temp_paths(tmp_path, monkeypatch)
+    cfg.remitente_adicional = 'otro@dominio.com;extra@dominio.com'
+    uidl_value = 'UID999'
+
+    raw_email = (
+        'Subject: SISTEMA NAF: Notificacion AUTORIZACION ORDEN COMPRA No 55555\r\n'
+        'From: Equipo <OTRO@DOMINIO.COM>\r\n'
+        '\r\n'
+        'Fecha Autorizacion: 10/11/2024\r\n'
+    ).encode('utf-8')
+
+    monkeypatch.setattr(escuchador, '_descargar_mensaje', lambda num, c: (uidl_value, raw_email))
+
+    def fake_pop(server, port):  # noqa: ARG001 - firmas compatibles
+        return DummyPOP(uidl_value)
+
+    monkeypatch.setattr(escuchador.poplib, 'POP3_SSL', fake_pop)
+
+    ordenes, _ = escuchador.buscar_ocs(cfg)
+
+    assert len(ordenes) == 1
+    assert ordenes[0]['numero'] == '55555'
+    assert not escuchador.PROCESADOS_FILE.exists()
+
+
+def test_reply_to_header_counts_as_valid_sender(tmp_path, monkeypatch, cfg):
+    _setup_temp_paths(tmp_path, monkeypatch)
+    uidl_value = 'UID444'
+
+    raw_email = (
+        'Subject: SISTEMA NAF: Notificacion AUTORIZACION ORDEN COMPRA No 77777\r\n'
+        'From: Plataforma <notificaciones@telconet.ec>\r\n'
+        'Reply-To: naf@telconet.ec\r\n'
+        '\r\n'
+        'Fecha Autorizacion: 03/04/2024\r\n'
+    ).encode('utf-8')
+
+    monkeypatch.setattr(escuchador, '_descargar_mensaje', lambda num, c: (uidl_value, raw_email))
+
+    def fake_pop(server, port):  # noqa: ARG001
+        return DummyPOP(uidl_value)
+
+    monkeypatch.setattr(escuchador.poplib, 'POP3_SSL', fake_pop)
+
+    ordenes, _ = escuchador.buscar_ocs(cfg)
+
+    assert len(ordenes) == 1
+    assert ordenes[0]['numero'] == '77777'
+    assert not escuchador.PROCESADOS_FILE.exists()
+
+
+def test_extracts_provider_from_html_body():
+    asunto = 'SISTEMA NAF: Notificacion AUTORIZACION ORDEN COMPRA No 140144463'
+    cuerpo = (
+        '<p><strong>Proveedor:</strong> '
+        '<strong>004465 - SALAZAR RUIZ MARCELO VLADIMIR</strong> '
+        'con <strong>Fecha de Vencimiento:</strong> 16/10/2025</p>'
+        '<br><p><strong>Observacion:</strong> '
+        'TAREA #140144463//PEDIDO:S/N//DETALLE</p>'
+    )
+
+    numero, _, _, proveedor, tarea = escuchador.extraer_datos(asunto, cuerpo)
+
+    assert numero == '140144463'
+    assert proveedor == '004465 - SALAZAR RUIZ MARCELO VLADIMIR'
+    assert tarea == '140144463'

--- a/DescargasOC-main/tests/test_mover_pdf.py
+++ b/DescargasOC-main/tests/test_mover_pdf.py
@@ -1,0 +1,48 @@
+import sys
+import types
+from types import SimpleNamespace
+
+fake_pdf = types.ModuleType("PyPDF2")
+fake_pdf.PdfReader = object
+sys.modules.setdefault("PyPDF2", fake_pdf)
+
+from descargas_oc import mover_pdf
+
+
+def test_mover_oc_bienes_registra_error_si_no_se_mueve(tmp_path, monkeypatch):
+    origen = tmp_path / "descargas"
+    destino = tmp_path / "destino"
+    origen.mkdir()
+    destino.mkdir()
+
+    pdf = origen / "123456.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+
+    cfg = SimpleNamespace(
+        compra_bienes=True,
+        carpeta_destino_local=str(origen),
+        carpeta_analizar=str(destino),
+        abastecimiento_carpeta_descarga=str(origen),
+    )
+
+    monkeypatch.setattr(
+        mover_pdf, "extraer_numero_tarea_desde_pdf", lambda ruta: "140144463"
+    )
+    monkeypatch.setattr(
+        mover_pdf, "extraer_proveedor_desde_pdf", lambda ruta: "Proveedor X"
+    )
+
+    def failing_move(src, dst):
+        raise PermissionError("sin permisos")
+
+    monkeypatch.setattr(mover_pdf.shutil, "move", failing_move)
+
+    subidos, faltantes, errores = mover_pdf.mover_oc(
+        cfg, [{"numero": "123456", "proveedor": "Proveedor X"}]
+    )
+
+    assert subidos == []
+    assert faltantes == ["123456"]
+    assert any("OC 123456" in msg for msg in errores)
+    # el PDF debe permanecer en la carpeta de origen para reintentos
+    assert any(item.suffix.lower() == ".pdf" for item in origen.iterdir())

--- a/DescargasOC-main/tests/test_ui_scan.py
+++ b/DescargasOC-main/tests/test_ui_scan.py
@@ -1,0 +1,108 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+class DummyText:
+    def __init__(self):
+        self.messages = []
+
+    def insert(self, index, text):  # pragma: no cover - simple storage
+        self.messages.append(text)
+
+    def see(self, index):  # pragma: no cover - noop for tests
+        pass
+
+    def after(self, delay, callback):
+        callback()
+
+
+class DummyLabel:
+    def __init__(self):
+        self.text = ""
+
+    def config(self, **kwargs):
+        if "text" in kwargs:
+            self.text = kwargs["text"]
+
+
+class DummyConfig:
+    def __init__(self):
+        self.usuario = "user@telconet.ec"
+        self.password = "secret"
+        self.carpeta_destino_local = "dest"
+        self.carpeta_analizar = "analizar"
+        self.seafile_url = "https://seafile"
+        self.seafile_repo_id = "repo"
+        self.correo_reporte = "report@telconet.ec"
+        self.headless = True
+
+    def validate(self):  # pragma: no cover - no validation logic
+        return True
+
+
+@pytest.fixture
+def ui_module(monkeypatch):
+    fake_pdf = types.ModuleType("PyPDF2")
+    fake_pdf.PdfReader = object
+    sys.modules["PyPDF2"] = fake_pdf
+    for mod in [
+        "descargas_oc.mover_pdf",
+        "descargas_oc.selenium_modulo",
+        "descargas_oc.ui",
+    ]:
+        sys.modules.pop(mod, None)
+    ui_mod = importlib.import_module("descargas_oc.ui")
+    yield ui_mod
+    sys.modules.pop("PyPDF2", None)
+
+
+@pytest.fixture(autouse=True)
+def reset_lock(ui_module):
+    if ui_module.scanning_lock.locked():
+        ui_module.scanning_lock.release()
+    yield
+    if ui_module.scanning_lock.locked():
+        ui_module.scanning_lock.release()
+
+
+def test_uidl_kept_pending_when_some_orders_fail(monkeypatch, ui_module):
+    monkeypatch.setattr(ui_module, "Config", DummyConfig)
+    monkeypatch.setattr(
+        ui_module,
+        "buscar_ocs",
+        lambda cfg: (
+            [
+                {"uidl": "UID1", "numero": "1001"},
+                {"uidl": "UID1", "numero": "1002"},
+                {"uidl": "UID2", "numero": "2001"},
+            ],
+            "UID_LAST",
+        ),
+    )
+    monkeypatch.setattr(
+        ui_module,
+        "descargar_oc",
+        lambda ordenes, headless: (["1001", "2001"], ["1002"], ["OC 1002: error"]),
+    )
+    monkeypatch.setattr(ui_module, "enviar_reporte", lambda *args, **kwargs: True)
+
+    calls = []
+
+    def fake_registrar(uidls, ultimo):
+        calls.append((uidls, ultimo))
+
+    monkeypatch.setattr(ui_module, "registrar_procesados", fake_registrar)
+    monkeypatch.setattr(ui_module, "cargar_ultimo_uidl", lambda: "PREV")
+    monkeypatch.setattr(ui_module.messagebox, "showerror", lambda *a, **k: None)
+    monkeypatch.setattr(ui_module.messagebox, "showinfo", lambda *a, **k: None)
+
+    text = DummyText()
+    label = DummyLabel()
+
+    ui_module.realizar_escaneo(text, label)
+
+    assert calls == [(["UID2"], None)]
+    assert "PREV" in label.text

--- a/DescargasOC-main/tests/test_upload.py
+++ b/DescargasOC-main/tests/test_upload.py
@@ -1,7 +1,10 @@
 import requests
-import requests_mock
 import sys
 from pathlib import Path
+
+import pytest
+
+requests_mock = pytest.importorskip('requests_mock')
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'descargas_oc'))
 from seafile_client import SeafileClient

--- a/GestorCompras_/gestorcompras/gui/reasignacion_gui.py
+++ b/GestorCompras_/gestorcompras/gui/reasignacion_gui.py
@@ -1,6 +1,5 @@
 import tkinter as tk
 from tkinter import ttk, messagebox, simpledialog
-from gestorcompras.theme import color_blanco, color_borde, color_titulos
 from gestorcompras.services import db
 import threading
 import time
@@ -307,7 +306,7 @@ def open_reasignacion(master, email_session):
     window.protocol("WM_DELETE_WINDOW", on_close)
 
     banner = ttk.Label(window, text="Sistema de automatización - compras")
-    banner.configure(font=("Helvetica", 24, "bold"), foreground=color_titulos)
+    banner.configure(font=("Helvetica", 24, "bold"), foreground="#222222")
     banner.pack(pady=(20,10))
 
     top_frame = ttk.Frame(window, style="MyFrame.TFrame", padding=5)
@@ -332,12 +331,8 @@ def open_reasignacion(master, email_session):
                              style="MyLabelFrame.TLabelframe", padding=5)
     task_lf.pack(fill="both", expand=True)
 
-    canvas = tk.Canvas(
-        task_lf,
-        background=color_blanco,
-        highlightthickness=1,
-        highlightbackground=color_borde,
-    )
+    canvas = tk.Canvas(task_lf, background="#FFFFFF", highlightthickness=1,
+                       highlightbackground="#CCCCCC")
     scrollbar = ttk.Scrollbar(task_lf, orient="vertical", command=canvas.yview)
     tasks_frame = ttk.Frame(canvas, style="MyFrame.TFrame")
 


### PR DESCRIPTION
## Summary
- keep UIDLs pending until every associated OC finishes successfully and only mark the successful ones as processed
- normalise HTML-formatted notification bodies so provider names and tasks are extracted correctly
- cover the new behaviours with tests for partial OC downloads and HTML-rich provider fields
- treat bienes downloads as failed when the PDF cannot be moved so the UIDL remains pending and the file stays available for retry, collecting the error message
- accept authorization emails whose trusted address appears in Reply-To/Sender headers and add regression tests for mover failures and sender parsing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8daf116d083208bcb0f100728bd19