### PR TITLE
Uppercase order download filenames

### DIFF
--- a/DescargasOC-main/descargas_oc/mover_pdf.py
+++ b/DescargasOC-main/descargas_oc/mover_pdf.py
@@ -217,8 +217,12 @@ def _nombre_destino(numero: str | None, proveedor: str | None, ext: str) -> str:
         base = base[:MAX_NOMBRE].rstrip(" .-_")
         if not base:
             base = "archivo"
-    if not ext.startswith("."):
-        ext = f".{ext}" if ext else ".pdf"
+    base = base.upper()
+    if not ext:
+        ext = ".PDF"
+    elif not ext.startswith("."):
+        ext = f".{ext}"
+    ext = ext.upper()
     return f"{base}{ext}"
 
 
@@ -386,7 +390,7 @@ def mover_oc(config: Config, ordenes=None):
         if not carpeta.exists():
             logger.warning("Carpeta origen inexistente: %s", carpeta)
             continue
-        archivos.extend(p for p in carpeta.glob("*.pdf"))
+        archivos.extend(p for p in carpeta.glob("*.[Pp][Dd][Ff]"))
 
     encontrados: dict[str, Path] = {}
     procesados_en_origen: set[Path] = set()
@@ -443,8 +447,10 @@ def mover_oc(config: Config, ordenes=None):
 #=======
         if prov:
             prov_clean = sanitize_filename(prov)
+            if prov_clean:
+                prov_clean = prov_clean.upper()
             nuevo_nombre = os.path.join(
-                carpeta_origen, f"{numero} - NOMBRE {prov_clean}.pdf"
+                carpeta_origen, f"{numero} - NOMBRE {prov_clean}.PDF"
             )
             if ruta != nuevo_nombre:
                 try:
@@ -453,8 +459,10 @@ def mover_oc(config: Config, ordenes=None):
                 except Exception as e:
                     logger.warning('No se pudo renombrar %s: %s', ruta, e)
                     prov_clean = sanitize_filename(prov, max_len=20)
+                    if prov_clean:
+                        prov_clean = prov_clean.upper()
                     nuevo_nombre = os.path.join(
-                        carpeta_origen, f"{numero} - NOMBRE {prov_clean}.pdf"
+                        carpeta_origen, f"{numero} - NOMBRE {prov_clean}.PDF"
                     )
                     try:
                         os.rename(ruta, nuevo_nombre)
@@ -471,7 +479,7 @@ def mover_oc(config: Config, ordenes=None):
             if indice_ordenes.get(numero) is not None:
                 indice_ordenes[numero]["tarea"] = tarea
 
-        ext = ruta_path.suffix or ".pdf"
+        ext = (ruta_path.suffix or ".PDF").upper()
         nombre_deseado = nombre_archivo_orden(numero, prov, ext)
         nombre_deseado = _nombre_destino(numero, prov, ext)
         nombre_original = ruta_path.name

--- a/DescargasOC-main/descargas_oc/pdf_info.py
+++ b/DescargasOC-main/descargas_oc/pdf_info.py
@@ -46,17 +46,19 @@ def nombre_archivo_orden(
         prov_clean = re.sub(r"[^\w\- ]", "_", proveedor)
         prov_clean = re.sub(r"\s+", "_", prov_clean)
         prov_clean = re.sub(r"_+", "_", prov_clean)
-        prov_clean = prov_clean.lstrip("_").lower()
+        prov_clean = prov_clean.lstrip("_").upper()
         base = f"{base} - {prov_clean}" if base else prov_clean
     base = re.sub(r"\s+", " ", base).strip()
     if not base:
         base = "archivo"
     if len(base) > MAX_NOMBRE_ARCHIVO:
         base = base[:MAX_NOMBRE_ARCHIVO].rstrip(" .-_") or "archivo"
+    base = base.upper()
     if not extension:
         extension = ".pdf"
     if not extension.startswith("."):
         extension = f".{extension}"
+    extension = extension.upper()
     return f"{base}{extension}"
 
 
@@ -108,7 +110,7 @@ def actualizar_proveedores_desde_pdfs(
     if not ordenes_dict:
         return {}
 
-    pdfs = sorted(carpeta.glob("*.pdf"))
+    pdfs = sorted(carpeta.glob("*.[Pp][Dd][Ff]"))
     if not pdfs:
         logger.debug("No se encontraron PDFs en %s", carpeta)
         return {}

--- a/DescargasOC-main/descargas_oc/reporter.py
+++ b/DescargasOC-main/descargas_oc/reporter.py
@@ -31,7 +31,7 @@ def _buscar_tarea(numero: str, cfg: Config) -> str | None:
     if not carpeta:
         return None
     # Buscar recursivamente por si los archivos fueron movidos a subcarpetas
-    for pdf in Path(carpeta).rglob(f"{numero}*.pdf"):
+    for pdf in Path(carpeta).rglob(f"{numero}*.[Pp][Dd][Ff]"):
         tarea = extraer_numero_tarea_desde_pdf(str(pdf))
         if tarea:
             return tarea

--- a/DescargasOC-main/descargas_oc/selenium_abastecimiento.py
+++ b/DescargasOC-main/descargas_oc/selenium_abastecimiento.py
@@ -166,7 +166,9 @@ def _nombre_archivo(numero: str | None, proveedor: str | None) -> str | None:
     if not partes:
         return None
     base = " - ".join(partes)
-    return base[:180].rstrip(" .-_") or None
+    base = base[:180].rstrip(" .-_") or ""
+    base = base.upper()
+    return base or None
 
 
 def _renombrar_descarga(archivo: Path, base: str | None) -> Path:
@@ -177,11 +179,12 @@ def _renombrar_descarga(archivo: Path, base: str | None) -> Path:
     base = base.strip()
     if not base:
         return archivo
+    base = base.upper()
 
-    destino = archivo.with_name(f"{base}.pdf")
+    destino = archivo.with_name(f"{base}.PDF")
     intento = 0
     while True:
-        candidato = destino if intento == 0 else archivo.with_name(f"{base} ({intento}).pdf")
+        candidato = destino if intento == 0 else archivo.with_name(f"{base} ({intento}).PDF")
         if archivo == candidato:
             return archivo
         try:
@@ -1143,7 +1146,9 @@ def descargar_abastecimiento(
         except Exception:
             numero = str(idx)
             proveedor = ""
-        existentes = {pdf: pdf.stat().st_mtime for pdf in destino.glob("*.pdf")}
+        existentes = {
+            pdf: pdf.stat().st_mtime for pdf in destino.glob("*.[Pp][Dd][Ff]")
+        }
         try:
             btn.click()
         except ElementClickInterceptedException:
@@ -1171,7 +1176,9 @@ def descargar_abastecimiento(
             ordenes.append(
                 {"numero": numero, "proveedor": proveedor, "categoria": "abastecimiento"}
             )
-            existentes = {pdf: pdf.stat().st_mtime for pdf in destino.glob("*.pdf")}
+            existentes = {
+                pdf: pdf.stat().st_mtime for pdf in destino.glob("*.[Pp][Dd][Ff]")
+            }
             try:
                 btn.click()
             except (ElementClickInterceptedException, StaleElementReferenceException):

--- a/DescargasOC-main/descargas_oc/selenium_modulo.py
+++ b/DescargasOC-main/descargas_oc/selenium_modulo.py
@@ -46,7 +46,7 @@ def esperar_descarga_pdf(
     while time.monotonic() < limite:
         time.sleep(intervalo)
         candidatos: list[tuple[float, Path]] = []
-        for pdf in directory.glob("*.pdf"):
+        for pdf in directory.glob("*.[Pp][Dd][Ff]"):
             try:
                 mtime = pdf.stat().st_mtime
             except FileNotFoundError:
@@ -87,7 +87,7 @@ def esperar_descarga_pdf(
     while time.monotonic() < limite:
         time.sleep(intervalo)
         candidatos: list[tuple[float, Path]] = []
-        for pdf in directory.glob("*.pdf"):
+        for pdf in directory.glob("*.[Pp][Dd][Ff]"):
             try:
                 mtime = pdf.stat().st_mtime
             except FileNotFoundError:
@@ -147,12 +147,16 @@ def descargar_oc(
     def _renombrar_descarga(archivo: Path, base: str | None) -> Path:
         if not base:
             return archivo
-        destino = download_dir / f"{base}.pdf"
+        base = base.strip()
+        if not base:
+            return archivo
+        base = base.upper()
+        destino = download_dir / f"{base}.PDF"
         if archivo == destino:
             return archivo
         intento = 0
         while True:
-            candidato = destino if intento == 0 else download_dir / f"{base} ({intento}).pdf"
+            candidato = destino if intento == 0 else download_dir / f"{base} ({intento}).PDF"
             try:
                 archivo.rename(candidato)
                 return candidato
@@ -368,7 +372,8 @@ def descargar_oc(
                     time.sleep(2)
                 boton_descarga = _find("descargar_orden", elements["descargar_orden"])
                 existentes = {
-                    pdf: pdf.stat().st_mtime for pdf in download_dir.glob("*.pdf")
+                    pdf: pdf.stat().st_mtime
+                    for pdf in download_dir.glob("*.[Pp][Dd][Ff]")
                 }
                 try:
                     boton_descarga.click()
@@ -398,10 +403,10 @@ def descargar_oc(
 #<<<<<<< codex/fix-email-scanning-for-descarga-normal-z71yhw
 #=======
 #=======
-                antes = set(download_dir.glob("*.pdf"))
+                antes = set(download_dir.glob("*.[Pp][Dd][Ff]"))
                 for _ in range(120):  # esperar hasta 60 s
                     time.sleep(0.5)
-                    nuevos = set(download_dir.glob("*.pdf")) - antes
+                    nuevos = set(download_dir.glob("*.[Pp][Dd][Ff]")) - antes
                     if nuevos:
                         archivo = nuevos.pop()
                         break
@@ -409,13 +414,17 @@ def descargar_oc(
                     raise RuntimeError("No se descargó archivo")
                 if not getattr(cfg, "compra_bienes", False) and proveedor:
                     prov_clean = sanitize_filename(proveedor)
-                    nuevo_nombre = download_dir / f"{numero} - {prov_clean}.pdf"
+                    if prov_clean:
+                        prov_clean = prov_clean.upper()
+                    nuevo_nombre = download_dir / f"{numero} - {prov_clean}.PDF"
                     try:
                         archivo.rename(nuevo_nombre)
                         archivo = nuevo_nombre
                     except Exception:
                         prov_clean = sanitize_filename(proveedor, max_len=20)
-                        nuevo_nombre = download_dir / f"{numero} - {prov_clean}.pdf"
+                        if prov_clean:
+                            prov_clean = prov_clean.upper()
+                        nuevo_nombre = download_dir / f"{numero} - {prov_clean}.PDF"
                         try:
                             archivo.rename(nuevo_nombre)
                             archivo = nuevo_nombre

--- a/DescargasOC-main/tests/test_mover_pdf.py
+++ b/DescargasOC-main/tests/test_mover_pdf.py
@@ -100,10 +100,10 @@ def test_mover_oc_bienes_copia_si_move_falla(tmp_path, monkeypatch):
     assert subidos == ["123456"]
     assert faltantes == []
     assert errores == []
-    archivos = list(carpeta_tarea.glob("*.pdf"))
+    archivos = list(carpeta_tarea.glob("*.[Pp][Dd][Ff]"))
     assert len(archivos) == 1
     assert archivos[0].name.startswith("123456")
-    assert not any(origen.glob("*.pdf"))
+    assert not any(origen.glob("*.[Pp][Dd][Ff]"))
 
 
 def test_mover_oc_reporta_error_si_no_puede_renombrar(tmp_path, monkeypatch):
@@ -149,11 +149,10 @@ def test_mover_oc_bienes_mueve_a_carpeta_existente(tmp_path, monkeypatch):
     assert subidos == ["123456"]
     assert faltantes == []
     assert errores == []
-    archivos = list(carpeta_tarea.glob("*.pdf"))
+    archivos = list(carpeta_tarea.glob("*.[Pp][Dd][Ff]"))
     assert len(archivos) == 1
-    assert "proveedor_x" in archivos[0].stem
-    assert "Proveedor X" in archivos[0].stem
-    assert not any(origen.glob("*.pdf"))
+    assert "PROVEEDOR_X" in archivos[0].stem
+    assert not any(origen.glob("*.[Pp][Dd][Ff]"))
 
 
 def test_mover_oc_bienes_resuelve_conflictos(tmp_path, monkeypatch):
@@ -164,7 +163,7 @@ def test_mover_oc_bienes_resuelve_conflictos(tmp_path, monkeypatch):
 
     carpeta_tarea = destino / "140144463"
     carpeta_tarea.mkdir()
-    conflicto = carpeta_tarea / "123456 - proveedor_x.pdf"
+    conflicto = carpeta_tarea / "123456 - PROVEEDOR_X.PDF"
 #<<<<<<< codex/fix-email-scanning-for-descarga-normal-z71yhw
     conflicto = carpeta_tarea / "123456 - Proveedor X.pdf"
 #=======
@@ -182,10 +181,10 @@ def test_mover_oc_bienes_resuelve_conflictos(tmp_path, monkeypatch):
     assert subidos == ["123456"]
     assert faltantes == []
     assert errores == []
-    archivos = sorted(carpeta_tarea.glob("*.pdf"))
+    archivos = sorted(carpeta_tarea.glob("*.[Pp][Dd][Ff]"))
     assert len(archivos) == 2
     nombres = [p.name for p in archivos]
-    assert any(name.endswith("(1).pdf") for name in nombres)
+    assert any(name.endswith("(1).PDF") for name in nombres)
 
 
 def test_mover_oc_no_bienes_identifica_numero_en_nombre(tmp_path):
@@ -201,10 +200,10 @@ def test_mover_oc_no_bienes_identifica_numero_en_nombre(tmp_path):
     assert subidos == ["123456"]
     assert faltantes == []
     assert errores == []
-    archivos = list(destino.glob("*.pdf"))
+    archivos = list(destino.glob("*.[Pp][Dd][Ff]"))
     assert len(archivos) == 1
-    assert archivos[0].name == "123456 - proveedor_x.pdf"
-    assert not any(origen.glob("*.pdf"))
+    assert archivos[0].name == "123456 - PROVEEDOR_X.PDF"
+    assert not any(origen.glob("*.[Pp][Dd][Ff]"))
 
 
 def test_mover_oc_no_bienes_renombra_en_origen_si_no_hay_destino(tmp_path):
@@ -221,9 +220,9 @@ def test_mover_oc_no_bienes_renombra_en_origen_si_no_hay_destino(tmp_path):
     assert subidos == ["654321"]
     assert faltantes == []
     assert errores == []
-    archivos = list(origen.glob("*.pdf"))
+    archivos = list(origen.glob("*.[Pp][Dd][Ff]"))
     assert len(archivos) == 1
-    assert archivos[0].name == "654321 - proveedor_y.pdf"
+    assert archivos[0].name == "654321 - PROVEEDOR_Y.PDF"
 
 
 def test_mover_oc_no_bienes_registra_error_si_no_puede_mover(tmp_path, monkeypatch):
@@ -301,11 +300,11 @@ def test_mover_oc_abastecimiento_permanecen_en_descarga(tmp_path):
     assert faltantes == []
     assert errores == []
 
-    archivos_abas = list(origen_abas.glob("*.pdf"))
+    archivos_abas = list(origen_abas.glob("*.[Pp][Dd][Ff]"))
     assert len(archivos_abas) == 1
-    assert archivos_abas[0].name.startswith("555555 - proveedor_uno")
+    assert archivos_abas[0].name.startswith("555555 - PROVEEDOR_UNO")
     # no se debe mover a la carpeta general
-    assert not list(destino_general.glob("*.pdf"))
+    assert not list(destino_general.glob("*.[Pp][Dd][Ff]"))
 def test_mover_oc_no_bienes_identifica_numero_en_nombre(tmp_path, monkeypatch):
     cfg, origen, _destino = _config(tmp_path, bienes=False)
 

--- a/DescargasOC-main/tests/test_pdf_info.py
+++ b/DescargasOC-main/tests/test_pdf_info.py
@@ -32,10 +32,10 @@ def test_nombre_archivo_orden_formatea_y_respeta_extension():
     modulo = importlib.import_module("descargas_oc.pdf_info")
 
     nombre = modulo.nombre_archivo_orden("123456", "Proveedor / Test", "pdf")
-    assert nombre == "123456 - proveedor_test.pdf"
+    assert nombre == "123456 - PROVEEDOR_TEST.PDF"
 
     nombre_sin_datos = modulo.nombre_archivo_orden(None, None, None)
-    assert nombre_sin_datos == "archivo.pdf"
+    assert nombre_sin_datos == "ARCHIVO.PDF"
 
 
 def test_proveedor_desde_pdf_normaliza(monkeypatch):

--- a/DescargasOC-main/tests/test_selenium_abastecimiento.py
+++ b/DescargasOC-main/tests/test_selenium_abastecimiento.py
@@ -15,11 +15,11 @@ def test_nombre_archivo_normaliza_datos():
 
     assert (
         modulo._nombre_archivo("123456", "Proveedor S.A.")
-        == "123456 - Proveedor S_A"
+        == "123456 - PROVEEDOR S_A"
     )
     assert (
         modulo._nombre_archivo("", "Proveedor Especial")
-        == "Proveedor Especial"
+        == "PROVEEDOR ESPECIAL"
     )
     assert modulo._nombre_archivo(None, None) is None
 
@@ -63,5 +63,5 @@ def test_renombrar_pdf_respeta_nombre_original(tmp_path):
 
     renombrado = modulo._renombrar_pdf_descargado(pdf, "342050", "Electroleg S.A.")
 
-    assert renombrado.name.startswith("ORDEN #342050 - electroleg_s_a_")
-    assert renombrado.suffix == ".pdf"
+    assert renombrado.name.startswith("ORDEN #342050 - ELECTROLEG_S_A_")
+    assert renombrado.suffix == ".PDF"


### PR DESCRIPTION
## Summary
- force generated order filenames to use uppercase components and extensions across download and move flows
- make PDF discovery tolerant to uppercase extensions when scanning directories
- align selenium and mover unit tests with the new uppercase naming rules

## Testing
- `PYTHONPATH=DescargasOC-main pytest DescargasOC-main/tests/test_pdf_info.py` *(fails: missing optional dependency `pypdf`)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c4e227b883209f9bca18e6fc89ee