### PR TITLE
Corrige login de Actua y agrega acceso visible a ejecutar flujo

### DIFF
--- a/GestorCompras_/gestorcompras/main.py
+++ b/GestorCompras_/gestorcompras/main.py
@@ -182,6 +182,7 @@ class LoginScreen(tk.Frame):
         if not username or not password:
             messagebox.showerror("Error", "Debe ingresar usuario y contrasena.", parent=self)
             return
+        username = username.split("@")[0].strip()
         email_address = f"{username}@telconet.ec"
 
         self.btn_login.config(state="disabled")
@@ -191,11 +192,11 @@ class LoginScreen(tk.Frame):
 
         def _do_login():
             success = test_email_connection(email_address, password)
-            self.after(0, lambda: self._on_login_result(success, email_address, password))
+            self.after(0, lambda: self._on_login_result(success, username, email_address, password))
 
         threading.Thread(target=_do_login, daemon=True).start()
 
-    def _on_login_result(self, success: bool, email_address: str, password: str) -> None:
+    def _on_login_result(self, success: bool, username: str, email_address: str, password: str) -> None:
         try:
             self.btn_login.config(state="normal")
             self.user_entry.config(state="normal")
@@ -205,6 +206,7 @@ class LoginScreen(tk.Frame):
             return
 
         if success:
+            email_session["username"] = username
             email_session["address"] = email_address
             email_session["password"] = password
             core_config.set_user_email(email_address)

--- a/GestorCompras_/gestorcompras/main.py
+++ b/GestorCompras_/gestorcompras/main.py
@@ -207,7 +207,9 @@ class LoginScreen(tk.Frame):
 
         if success:
             email_session["username"] = username
+            email_session["user"] = username
             email_session["address"] = email_address
+            email_session["email"] = email_address
             email_session["password"] = password
             core_config.set_user_email(email_address)
             messagebox.showinfo("Bienvenido", "Inicio de sesion correcto.", parent=self)

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -50,12 +50,35 @@ _ORIGEN_COLUMNS: dict[str, list[tuple[str, str]]] = {
 }
 
 
-def _resolve_telcos_credentials(session: dict[str, str]) -> tuple[str, str]:
-    username = (session.get("username") or "").strip()
+def _resolve_telcos_credentials(session: dict[str, str] | None) -> tuple[str, str]:
+    session = session or {}
+    username = (
+        session.get("username")
+        or session.get("user")
+        or session.get("usuario")
+        or ""
+    ).strip()
     if not username:
-        username = (session.get("address") or "").strip().split("@")[0]
-    username = username.split("@")[0].strip()
-    password = (session.get("password") or "").strip()
+        address = (
+            session.get("address")
+            or session.get("email")
+            or session.get("correo")
+            or ""
+        ).strip()
+        username = address.split("@")[0] if address else ""
+    if not username:
+        try:
+            from gestorcompras.core import config as core_config
+            username = (core_config.get_user_email() or "").split("@")[0].strip()
+        except Exception:
+            username = ""
+    username = username.split("@")[0].strip().upper()
+    password = (
+        session.get("password")
+        or session.get("pass")
+        or session.get("contrasena")
+        or ""
+    ).strip()
     return username, password
 
 

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -50,6 +50,15 @@ _ORIGEN_COLUMNS: dict[str, list[tuple[str, str]]] = {
 }
 
 
+def _resolve_telcos_credentials(session: dict[str, str]) -> tuple[str, str]:
+    username = (session.get("username") or "").strip()
+    if not username:
+        username = (session.get("address") or "").strip().split("@")[0]
+    username = username.split("@")[0].strip()
+    password = (session.get("password") or "").strip()
+    return username, password
+
+
 def _required_keys_for_flow(pasos: list[dict]) -> set[str]:
     """Extrae las claves de contexto ({clave}) requeridas por un flujo."""
     keys: set[str] = set()
@@ -558,8 +567,9 @@ class ActuaTareasScreen(ttk.Frame):
                     raise ValueError("Debe ingresar al menos una tarea manual o seleccionar tareas de bandeja.")
 
                 driver = _create_driver(headless=not self.mostrar_nav_var.get())
-                username = (self.email_session.get("address") or "").split("@")[0]
-                password = self.email_session.get("password") or ""
+                username, password = _resolve_telcos_credentials(self.email_session)
+                if not username or not password:
+                    raise ValueError("Credenciales de Telcos no disponibles.")
                 login_telcos(driver, username, password)
 
                 consumidas_ok: list[int] = []
@@ -678,6 +688,7 @@ class ActuaExecutionPanel(tk.Toplevel):
         for txt, cmd in (
             ("Escanear correos", self._scan_emails),
             ("Agregar manual", self._add_manual),
+            ("Ejecutar flujo", self._ejecutar),
             ("Editar", self._edit_task),
             ("Eliminar", self._delete_tasks),
             ("Seleccionar todo", self._select_all),
@@ -1047,8 +1058,7 @@ class ActuaExecutionPanel(tk.Toplevel):
                 return
 
             try:
-                username = (self.email_session.get("address") or "").split("@")[0]
-                password = self.email_session.get("password") or ""
+                username, password = _resolve_telcos_credentials(self.email_session)
                 if not username or not password:
                     raise ValueError("Credenciales de Telcos no disponibles.")
                 self._log_msg(f"Iniciando sesion en Telcos como {username}...")
@@ -1208,8 +1218,7 @@ def run_flow_from_inbox(
                 return
 
             try:
-                username = (email_session.get("address") or "").split("@")[0]
-                password = email_session.get("password") or ""
+                username, password = _resolve_telcos_credentials(email_session)
                 if not username or not password:
                     raise ValueError("Credenciales de Telcos no disponibles en la sesión.")
                 log(f"Iniciando sesión en Telcos como {username}…")

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -258,6 +258,7 @@ class ActuaTareasScreen(ttk.Frame):
         self.manual_tasks_text = tk.Text(bottom, height=3, width=36, relief="solid",
                                           borderwidth=1, font=("Segoe UI", 10))
         self.manual_tasks_text.grid(row=1, column=1, columnspan=2, sticky="ew", pady=(6, 0))
+        self.manual_tasks_text.bind("<Control-Return>", lambda _e: self._run_flow())
 
         source_frame = ttk.LabelFrame(bottom, text="Origen de tareas", style="MyLabelFrame.TLabelframe", padding=6)
         source_frame.grid(row=1, column=3, columnspan=2, sticky="ew", padx=(8, 0), pady=(6, 0))
@@ -269,16 +270,19 @@ class ActuaTareasScreen(ttk.Frame):
         btn_all = ttk.Button(source_frame, text="Todos", command=self._inbox_select_all)
         btn_none = ttk.Button(source_frame, text="Ninguno", command=self._inbox_select_none)
         btn_clear = ttk.Button(source_frame, text="Limpiar", command=self._inbox_clear)
+        btn_manual_run = ttk.Button(source_frame, text="Ejecutar manual", command=self._run_flow)
         btn_all.grid(row=0, column=1, padx=3)
         btn_none.grid(row=0, column=2, padx=3)
         btn_clear.grid(row=0, column=3, padx=3)
+        btn_manual_run.grid(row=0, column=4, padx=3)
+        add_hover_effect(btn_manual_run)
 
         self.inbox_tree = ttk.Treeview(source_frame, columns=("sel", "origen", "task"),
                                        show="headings", style="MyTreeview.Treeview", height=3)
         for col, txt, w in (("sel", "✓", 30), ("origen", "Origen", 110), ("task", "Tarea", 110)):
             self.inbox_tree.heading(col, text=txt)
             self.inbox_tree.column(col, width=w, anchor="center")
-        self.inbox_tree.grid(row=1, column=0, columnspan=4, sticky="ew", pady=(6, 0))
+        self.inbox_tree.grid(row=1, column=0, columnspan=5, sticky="ew", pady=(6, 0))
         self.inbox_tree.bind("<Button-1>", self._toggle_inbox_row)
 
         ttk.Checkbutton(bottom, text="Mostrar navegador al ejecutar",


### PR DESCRIPTION
### Motivation
- Evitar fallos al ejecutar flujos de "Actualizar Tareas" causados porque se estaba usando el `address` con dominio para autenticarse en Telcos en lugar del `username` sin `@telconet.ec`.
- Reutilizar el mismo login del programa (normalizado) para las distintas rutas que inician sesiones en Telcos.
- Mejorar la usabilidad exponiendo de forma visible la acción de ejecutar flujo cuando se trabajan tareas manuales.

### Description
- Normaliza el usuario en la pantalla de login guardando `username` (sin dominio) además de `address` y `password` en `email_session` en `GestorCompras_/gestorcompras/main.py` (separando el `@telconet.ec`).
- Añade el helper `_resolve_telcos_credentials(session)` en `GestorCompras_/gestorcompras/ui/actua_tareas_gui.py` para obtener `username` (sin dominio) y `password` de la sesión.
- Reemplaza el uso directo de `address.split("@")[0]` por el resolvedor en las tres rutas de ejecución de flujos del módulo Actua: la pantalla principal (`_run_flow`), el panel de ejecución (`ActuaExecutionPanel._worker`) y la ejecución desde bandeja (`run_flow_from_inbox`).
- Añade validaciones que lanzan un error claro cuando faltan credenciales de Telcos y agrega el botón `"Ejecutar flujo"` en la barra superior del panel de ejecución para mayor visibilidad (`ActuaExecutionPanel` toolbar).

### Testing
- Se compiló el código modificado con `python -m compileall GestorCompras_/gestorcompras/main.py GestorCompras_/gestorcompras/ui/actua_tareas_gui.py` y la compilación finalizó correctamente.
- No se ejecutaron tests unitarios adicionales automáticamente en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d2f116848320825838477ffe7e26)