### PR TITLE
Evitar tareas pendientes duplicadas en task_inbox

### DIFF
--- a/GestorCompras_/gestorcompras/services/task_inbox.py
+++ b/GestorCompras_/gestorcompras/services/task_inbox.py
@@ -24,12 +24,19 @@ def _ensure_table() -> None:
             )
             """
         )
+        cur.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_actua_bandeja_pending_unique
+            ON actua_bandeja (origen, task_number)
+            WHERE consumed=0
+            """
+        )
         conn.commit()
     finally:
         conn.close()
 
 
-def push(origen: str, tasks: list[dict[str, Any]]) -> int:
+def push(origen: str, tasks: list[dict[str, Any]]) -> dict[str, int]:
     _ensure_table()
     origen = (origen or "").strip().lower()
     if origen not in VALID_ORIGINS:
@@ -37,19 +44,38 @@ def push(origen: str, tasks: list[dict[str, Any]]) -> int:
 
     conn = db.get_connection()
     inserted = 0
+    skipped_duplicates = 0
     try:
         cur = conn.cursor()
         for task in tasks:
             task_number = str(task.get("task_number", "")).strip()
             if not task_number:
                 continue
+
+            cur.execute(
+                """
+                SELECT 1
+                FROM actua_bandeja
+                WHERE origen=? AND task_number=? AND consumed=0
+                LIMIT 1
+                """,
+                (origen, task_number),
+            )
+            already_pending = cur.fetchone() is not None
+            if already_pending:
+                skipped_duplicates += 1
+                continue
+
             cur.execute(
                 "INSERT INTO actua_bandeja (origen, task_number, payload_json, consumed) VALUES (?, ?, ?, 0)",
                 (origen, task_number, json.dumps(task, ensure_ascii=False)),
             )
             inserted += 1
         conn.commit()
-        return inserted
+        return {
+            "inserted": inserted,
+            "skipped_duplicates": skipped_duplicates,
+        }
     finally:
         conn.close()
 


### PR DESCRIPTION
### Motivation
- Evitar que se inserten tareas pendientes duplicadas con el mismo `origen` y `task_number` cuando `consumed=0`, evitando sobrecarga y re-procesos innecesarios en la bandeja.
- Proveer retroalimentación a la UI sobre cuántas tareas fueron insertadas y cuántas se omitieron por ser duplicados para mostrar avisos útiles.

### Description
- Añade un índice único parcial en `_ensure_table`: `idx_actua_bandeja_pending_unique` sobre `(origen, task_number)` con `WHERE consumed=0` para evitar duplicados a nivel de BD.
- En `push`, antes de insertar, se comprueba si ya existe una entrada pendiente con el mismo `origen` y `task_number` y se omite la inserción si existe.
- `push` ahora contabiliza `skipped_duplicates` además de `inserted` y retorna un diccionario con ambas cuentas en lugar de un entero simple.
- Mantiene la validación de `origen` y la lógica de `list_pending`, `mark_consumed` y `clear` sin cambios funcionales.

### Testing
- Se ejecutó `python -m py_compile GestorCompras_/gestorcompras/services/task_inbox.py` y completó correctamente, confirmando que el módulo compila sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7657adb48320a62ca8369f420d37)