### PR TITLE
Normalizar destinatario del reporte de reasignación de servicios

### DIFF
--- a/GestorCompras_/gestorcompras/modules/reasignacion_gui.py
+++ b/GestorCompras_/gestorcompras/modules/reasignacion_gui.py
@@ -416,6 +416,13 @@ class ServiciosReasignacion(tk.Toplevel):
         from gestorcompras.services.email_task_scanner import normalize_for_search
         return normalize_for_search(value)
 
+    @staticmethod
+    def _normalize_email(address: str | None) -> str:
+        value = (address or "").strip()
+        if value and "@" not in value:
+            return f"{value}@telconet.ec"
+        return value
+
     def _buscar(self) -> None:
         cfg = core_config.get_servicios_config()
         correo_usuario = self._correo_usuario or self.email_session.get("address", "")
@@ -647,9 +654,13 @@ class ServiciosReasignacion(tk.Toplevel):
         try:
             from gestorcompras.services.reassign_reporter import enviar_reporte_servicios
 
+            destinatario_reporte = self.email_session.get("address", "") or self._correo_usuario
+            destinatario_reporte = self._normalize_email(destinatario_reporte)
+            logger.info("Destinatario final de reporte de reasignación: %s", destinatario_reporte or "(vacío)")
+
             enviar_reporte_servicios(
                 self.email_session,
-                self._correo_usuario,
+                destinatario_reporte,
                 exitosos,
                 fallidos,
             )

--- a/GestorCompras_/gestorcompras/services/reassign_reporter.py
+++ b/GestorCompras_/gestorcompras/services/reassign_reporter.py
@@ -60,6 +60,12 @@ _HTML_TEMPLATE = """
 """
 
 
+def _ensure_email(address: str) -> str:
+    if "@" not in address:
+        return f"{address}@telconet.ec"
+    return address
+
+
 def _formatear_filas(filas: Iterable[Dict[str, object]]) -> List[Dict[str, str]]:
     resultado: List[Dict[str, str]] = []
     for fila in filas:
@@ -93,7 +99,8 @@ def enviar_reporte_servicios(
 ) -> bool:
     """Envía un resumen de las tareas reasignadas y las que fallaron."""
 
-    if not email_session or not destinatario:
+    destinatario_normalizado = _ensure_email((destinatario or "").strip()) if destinatario else ""
+    if not email_session or not destinatario_normalizado:
         logger.debug("No se envía reporte: faltan credenciales o destinatario")
         return False
 
@@ -105,7 +112,7 @@ def enviar_reporte_servicios(
         return False
 
     contexto = {
-        "email_to": destinatario,
+        "email_to": destinatario_normalizado,
         "filas_ok": filas_ok,
         "filas_fail": filas_fail,
     }
@@ -118,7 +125,7 @@ def enviar_reporte_servicios(
             contexto,
             cc_key="EMAIL_CC_REASIGNACION",
         )
-        logger.info("Reporte de reasignación enviado a %s", destinatario)
+        logger.info("Reporte de reasignación enviado a %s", destinatario_normalizado)
         return True
     except Exception as exc:  # pragma: no cover - la entrega puede fallar por red
         logger.warning("No se pudo enviar el reporte de reasignación: %s", exc)


### PR DESCRIPTION
### Motivation
- Evitar envíos a direcciones incompletas anexando `@telconet.ec` cuando el destinatario no incluye dominio. 
- Priorizar la dirección de la sesión SMTP activa para que el reporte llegue al remitente real en uso. 
- Facilitar soporte registrando en el log el destinatario final normalizado antes del envío.

### Description
- Agrega helper ` _ensure_email(address)` en `gestorcompras/services/reassign_reporter.py` que anexa `@telconet.ec` si falta el `@` y lo usa para normalizar el `destinatario` antes de construir el contexto de correo. 
- En `enviar_reporte_servicios` se pasa el destinatario normalizado como `email_to` al `contexto` y se registra el destinatario normalizado en el log tras el envío. 
- Añade `ServiciosReasignacion._normalize_email` en `gestorcompras/modules/reasignacion_gui.py` y se prioriza `email_session["address"]` como destinatario del reporte, usando `self._correo_usuario` solo como fallback. 
- Mantiene la autenticación SMTP usando `email_session["address"]` y `password`, sin cambios en la forma de login a `send_email_custom`.

### Testing
- Se compiló el código modificado con `python -m compileall GestorCompras_/gestorcompras/services/reassign_reporter.py GestorCompras_/gestorcompras/modules/reasignacion_gui.py` y la compilación completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef765e288c83208b17d0d41bf5f96d)