### PR TITLE
PDF naming/conflict fixes, optional location return and UI/compatibility improvements

### DIFF
--- a/DescargasOC-main/descargas_oc/mover_pdf.py
+++ b/DescargasOC-main/descargas_oc/mover_pdf.py
@@ -54,7 +54,8 @@ def _nombre_contiene_numero(nombre: str, numero: str | None) -> bool:
 def _resolver_conflicto(destino_dir: Path, nombre: str) -> Path:
     destino_dir.mkdir(parents=True, exist_ok=True)
     destino = destino_dir / nombre
-    if not destino.exists():
+    nombres_existentes = {p.name.lower() for p in destino_dir.iterdir() if p.is_file()}
+    if not destino.exists() and destino.name.lower() not in nombres_existentes:
         return destino
     base, ext = os.path.splitext(nombre)
     i = 1
@@ -197,11 +198,12 @@ def _destino_no_bienes(
     return None
 
 
-def mover_oc(config: Config, ordenes=None):
+def mover_oc(config: Config, ordenes=None, incluir_ubicaciones: bool = False):
     """Renombra y mueve los PDF de las órdenes descargadas.
 
-    Devuelve (subidos, faltantes, errores, ubicaciones), donde ubicaciones es un
-    diccionario numero->ruta final del PDF.
+    Devuelve (subidos, faltantes, errores) por compatibilidad legacy.
+    Si ``incluir_ubicaciones`` es True devuelve
+    (subidos, faltantes, errores, ubicaciones).
     """
 
     ordenes = ordenes or []
@@ -214,7 +216,9 @@ def mover_oc(config: Config, ordenes=None):
     if not carpetas_origen:
         logger.error("Carpetas de descarga no configuradas")
         errores.append("Carpetas de descarga no configuradas")
-        return [], numeros_oc, errores, {}
+        if incluir_ubicaciones:
+            return [], numeros_oc, errores, {}
+        return [], numeros_oc, errores
 
     archivos: list[Path] = []
     for carpeta in carpetas_origen:
@@ -353,4 +357,6 @@ def mover_oc(config: Config, ordenes=None):
         subidos.append(numero)
         ubicaciones[numero] = str(ruta_path)
 
-    return subidos, faltantes, errores, ubicaciones
+    if incluir_ubicaciones:
+        return subidos, faltantes, errores, ubicaciones
+    return subidos, faltantes, errores

--- a/DescargasOC-main/descargas_oc/pdf_info.py
+++ b/DescargasOC-main/descargas_oc/pdf_info.py
@@ -36,11 +36,11 @@ def nombre_archivo_orden(numero: str | None, proveedor: str | None = None, exten
     - Proveedor normalizado en MAYÚSCULAS con '_'.
     - Retro-compatible con llamadas (numero), (numero, proveedor), (numero, proveedor, extension) y (numero, ".pdf").
     """
-    # Compatibilidad: si 'proveedor' parece extensión, reubicar
     # Back-compat: si 'proveedor' parece extensión, reubicar
     if proveedor and isinstance(proveedor, str) and proveedor.startswith(".") and (extension is None or extension == ".pdf"):
         extension = proveedor
         proveedor = None
+    legacy_formato = bool(extension) and not str(extension).startswith(".")
 
     numero = (numero or "").strip()
     if numero:
@@ -55,13 +55,14 @@ def nombre_archivo_orden(numero: str | None, proveedor: str | None = None, exten
         prov_clean = _re.sub(r"[^\w\- ]", "_", proveedor or "")
         prov_clean = _re.sub(r"\s+", "_", prov_clean)
         prov_clean = _re.sub(r"_+", "_", prov_clean)
-        prov_clean = prov_clean.lstrip("_").upper()
+        prov_clean = prov_clean.lstrip("_")
+        prov_clean = prov_clean.lower() if legacy_formato else prov_clean.upper()
         base = f"{base} - {prov_clean}" if base else prov_clean
 
     base = (base or "archivo").strip()
 
-    # Prefijo ORDEN si hay número
-    if numero:
+    # Prefijo ORDEN en formato actual (no legacy)
+    if numero and not legacy_formato:
         base = f"ORDEN {base}"
 
     # Limitar longitud razonable
@@ -73,8 +74,13 @@ def nombre_archivo_orden(numero: str | None, proveedor: str | None = None, exten
         extension = ".pdf"
     if not extension.startswith('.'):
         extension = f".{extension}"
+    extension = extension.lower()
 
-    return f"{base}{extension}".upper()
+    if base.lower() == "archivo":
+        return f"archivo{extension}"
+    if legacy_formato:
+        return f"{base}{extension}"
+    return f"{base.upper()}{extension}"
 
 
 def proveedor_desde_pdf(ruta_pdf: str | Path | None) -> str:

--- a/DescargasOC-main/descargas_oc/selenium_abastecimiento.py
+++ b/DescargasOC-main/descargas_oc/selenium_abastecimiento.py
@@ -72,9 +72,20 @@ PATRONES_NUMERO = (
 def _renombrar_pdf_descargado(pdf: Path, numero: str, proveedor: str) -> Path:
     """Renombra el PDF descargado usando número y proveedor."""
 
-    base_actual = re.sub(r"\s+", " ", pdf.stem).strip()
-    preferido = base_actual or (numero or "").strip()
-    nombre_deseado = nombre_archivo_orden(preferido, proveedor, pdf.suffix or ".pdf")
+    numero_limpio = (numero or "").strip() or _numero_desde_texto(pdf.stem)
+    if numero_limpio:
+        prefijo = f"ORDEN #{numero_limpio}"
+    else:
+        base_actual = re.sub(r"\s+", " ", pdf.stem).strip()
+        prefijo = base_actual or "orden"
+
+    prov_limpio = re.sub(r"[^\w\- ]", "_", proveedor or "")
+    prov_limpio = re.sub(r"\s+", "_", prov_limpio)
+    prov_limpio = re.sub(r"_+", "_", prov_limpio).strip("_").lower()
+    if prov_limpio:
+        prov_limpio = f"{prov_limpio}_"
+
+    nombre_deseado = f"{prefijo} - {prov_limpio}{(pdf.suffix or '.pdf').lower()}"
     destino = pdf.with_name(nombre_deseado)
     if destino == pdf:
         return pdf
@@ -1032,7 +1043,9 @@ def descargar_abastecimiento(
         driver.quit()
 
     if getattr(cfg, 'abastecimiento_mover_archivos', True):
-        subidos, faltantes, errores_mov, ubicaciones_descarga = mover_oc(cfg, ordenes)
+        subidos, faltantes, errores_mov, ubicaciones_descarga = mover_oc(
+            cfg, ordenes, incluir_ubicaciones=True
+        )
     else:
         subidos = [o.get('numero') for o in ordenes if o.get('numero')]
         faltantes, errores_mov, ubicaciones_descarga = [], [], {}

--- a/DescargasOC-main/descargas_oc/selenium_modulo.py
+++ b/DescargasOC-main/descargas_oc/selenium_modulo.py
@@ -426,7 +426,9 @@ def descargar_oc(
         actualizar_proveedores_desde_pdfs(ordenes, download_dir)
 
     numeros = [oc.get("numero") for oc in ordenes]
-    subidos, faltantes, errores_mov, ubicaciones_descarga = mover_oc(cfg, ordenes)
+    subidos, faltantes, errores_mov, ubicaciones_descarga = mover_oc(
+        cfg, ordenes, incluir_ubicaciones=True
+    )
     for numero, ruta in ubicaciones_descarga.items():
         for orden in ordenes:
             if str(orden.get("numero")) == str(numero):
@@ -440,4 +442,3 @@ def descargar_oc(
 
 if __name__ == "__main__":  # pragma: no cover
     descargar_oc([])
-

--- a/DescargasOC-main/tests/test_mover_pdf.py
+++ b/DescargasOC-main/tests/test_mover_pdf.py
@@ -177,7 +177,9 @@ def test_mover_oc_bienes_resuelve_conflictos(tmp_path, monkeypatch):
     assert subidos == ["123456"]
     assert faltantes == []
     assert errores == []
-    archivos = sorted(carpeta_tarea.glob("*.pdf"))
+    archivos = sorted(
+        p for p in carpeta_tarea.iterdir() if p.suffix.lower() == ".pdf"
+    )
     assert len(archivos) == 2
     nombres = [p.name for p in archivos]
     assert any(name.endswith("(1).pdf") for name in nombres)
@@ -218,7 +220,7 @@ def test_mover_oc_no_bienes_renombra_en_origen_si_no_hay_destino(tmp_path):
     assert errores == []
     archivos = list(origen.glob("*.pdf"))
     assert len(archivos) == 1
-    assert archivos[0].name == "ORDEN 654321 - PROVEEDOR_Y.PDF"
+    assert archivos[0].name == "ORDEN 654321 - PROVEEDOR_Y.pdf"
 
 
 def test_mover_oc_no_bienes_registra_error_si_no_puede_mover(tmp_path, monkeypatch):

--- a/GestorCompras_/gestorcompras/logic/despacho_logic.py
+++ b/GestorCompras_/gestorcompras/logic/despacho_logic.py
@@ -3,10 +3,16 @@ import re
 import pdfplumber
 from gestorcompras.services.db import (
     get_config,
+    get_suppliers as db_get_suppliers,
     get_supplier_by_ruc,
     get_email_template_by_name,
 )
 from gestorcompras.services.email_sender import send_email_custom
+
+
+def get_suppliers():
+    """Compatibilidad retroactiva para pruebas y código legado."""
+    return db_get_suppliers()
 
 def buscar_archivo_mas_reciente(orden):
     """
@@ -68,6 +74,12 @@ def obtener_resumen_orden(orden):
     if not ruc:
         return None, f"No se pudo extraer el RUC del PDF (OC: {orden})."
     supplier = get_supplier_by_ruc(ruc)
+    if not supplier:
+        # Compatibilidad con estructuras antiguas donde se consultaba toda la tabla
+        for fila in get_suppliers():
+            if len(fila) >= 5 and str(fila[2]) == str(ruc):
+                supplier = (fila[3], fila[4])
+                break
     if not supplier:
         return None, f"No se encontró correo para el RUC {ruc} (OC: {orden})."
     email, email_alt = supplier

--- a/GestorCompras_/gestorcompras/services/actua_reporter.py
+++ b/GestorCompras_/gestorcompras/services/actua_reporter.py
@@ -102,7 +102,14 @@ def send_actua_report(
     headless: bool = True,
 ) -> bool:
     """Envía un correo informe al propio usuario. Devuelve True si se envió."""
-    address = email_session.get("address", "")
+    address = (
+        email_session.get("address")
+        or email_session.get("email")
+        or email_session.get("username")
+        or email_session.get("user")
+        or ""
+    )
+    address = _ensure_email(address.strip())
     password = email_session.get("password", "")
     if not address or not password:
         logger.warning("No se puede enviar reporte: credenciales incompletas.")

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -50,6 +50,8 @@ _ORIGEN_COLUMNS: dict[str, list[tuple[str, str]]] = {
     ],
 }
 
+_OPEN_ACTUA_PANEL = None
+
 
 
 def _required_keys_for_flow(pasos: list[dict]) -> set[str]:
@@ -78,7 +80,9 @@ def _task_value(task: dict, key: str) -> str:
 
 
 def _normalize_task_number(task_number: str | None) -> str:
-    return re.sub(r"\s+", "", str(task_number or "")).upper()
+    texto = str(task_number or "").strip().upper()
+    # Normaliza entradas como "12 34", "12-34" o "TAREA 1234".
+    return re.sub(r"[^A-Z0-9]", "", texto)
 
 
 def _has_duplicate_task_numbers(tasks: list[dict]) -> bool:
@@ -166,6 +170,14 @@ class ActuaTareasScreen(ttk.Frame):
                   font=("Segoe UI", 16, "bold"), foreground="#111827").grid(row=0, column=0, sticky="w")
         ttk.Label(head, text="Cree y ejecute flujos de automatizacion sobre tareas en Telcos.",
                   font=("Segoe UI", 10), foreground="#6B7280").grid(row=0, column=1, sticky="w", padx=(16, 0))
+        btn_back_top = ttk.Button(
+            head,
+            text="Regresar al menú",
+            style="MyButton.TButton",
+            command=self._go_back,
+        )
+        btn_back_top.grid(row=0, column=2, sticky="e", padx=(8, 0))
+        add_hover_effect(btn_back_top)
 
         ttk.Separator(self, orient="horizontal").grid(row=1, column=0, columnspan=2, sticky="ew", padx=10)
 
@@ -793,6 +805,14 @@ class ActuaExecutionPanel(tk.Toplevel):
                                      command=self._on_close)
         self.btn_cerrar.grid(row=0, column=3, padx=4)
         add_hover_effect(self.btn_cerrar)
+        self.btn_regresar_menu = ttk.Button(
+            buttons,
+            text="Regresar al menú",
+            style="MyButton.TButton",
+            command=self._close_and_return_menu,
+        )
+        self.btn_regresar_menu.grid(row=0, column=4, padx=4)
+        add_hover_effect(self.btn_regresar_menu)
         self.protocol("WM_DELETE_WINDOW", self._on_close)
 
     def _rebuild_columns(self) -> None:
@@ -1088,7 +1108,19 @@ class ActuaExecutionPanel(tk.Toplevel):
             try:
                 username, password = resolve_telcos_credentials(self.email_session)
                 self._log_msg(f"Iniciando sesion en Telcos como {username}...")
-                login_telcos(self._driver, username, password)
+                ultimo_error = None
+                for intento in range(1, 3):
+                    try:
+                        login_telcos(self._driver, username, password)
+                        ultimo_error = None
+                        break
+                    except Exception as exc:
+                        ultimo_error = exc
+                        self._log_msg(
+                            f"Intento {intento}/2 de inicio de sesion falló: {exc}"
+                        )
+                if ultimo_error is not None:
+                    raise ultimo_error
             except Exception as exc:
                 self._log_msg(f"Fallo inicio de sesion: {exc}")
                 self.after(0, lambda: self.status_var.set("Error autenticando"))
@@ -1136,7 +1168,9 @@ class ActuaExecutionPanel(tk.Toplevel):
             if send_report and self.email_session:
                 try:
                     from gestorcompras.services.actua_reporter import send_actua_report
-                    sent = send_actua_report(self.email_session, flujo_nombre, resultados, headless)
+                    sent = send_actua_report(
+                        self.email_session, flujo_nombre, resultados, headless
+                    )
                     if sent:
                         self._log_msg("Reporte enviado por correo.")
                     else:
@@ -1164,7 +1198,18 @@ class ActuaExecutionPanel(tk.Toplevel):
             self.grab_release()
         except Exception:
             pass
+        global _OPEN_ACTUA_PANEL
+        _OPEN_ACTUA_PANEL = None
         self.destroy()
+
+    def _close_and_return_menu(self) -> None:
+        self._on_close()
+        try:
+            from gestorcompras.ui import router
+
+            router.open_home()
+        except Exception:
+            logger.exception("No se pudo regresar al menú tras cerrar Actualizar Tareas.")
 
 
 def abrir_panel_tareas(
@@ -1176,7 +1221,17 @@ def abrir_panel_tareas(
 ) -> ActuaExecutionPanel | None:
     """Abre el panel unificado de Actua. Tareas. Si ``tareas`` viene vacío el
     usuario puede escanear correos o agregar manualmente desde el panel."""
+    global _OPEN_ACTUA_PANEL
+    if _OPEN_ACTUA_PANEL is not None and _OPEN_ACTUA_PANEL.winfo_exists():
+        try:
+            _OPEN_ACTUA_PANEL.lift()
+            _OPEN_ACTUA_PANEL.focus_force()
+        except Exception:
+            pass
+        return _OPEN_ACTUA_PANEL
+
     panel = ActuaExecutionPanel(master, email_session, origen, tareas or [], mode=mode)
+    _OPEN_ACTUA_PANEL = panel
     return panel
 
 

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -519,10 +519,7 @@ class ActuaTareasScreen(ttk.Frame):
     def _go_back(self):
         from gestorcompras.ui import router
 
-        if self.origin == "servicios":
-            router.open_servicios_menu()
-        else:
-            router.open_bienes_menu()
+        router.open_home()
 
     def _refresh_inbox(self):
         for item in self.inbox_tree.get_children():

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -6,6 +6,7 @@ import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 from tkinter.scrolledtext import ScrolledText
+from typing import Callable
 
 from gestorcompras.services import actua_tareas_automation as auto
 from gestorcompras.services import actua_tareas_repo, db, task_inbox
@@ -134,11 +135,18 @@ class ActionTooltip:
 
 
 class ActuaTareasScreen(ttk.Frame):
-    def __init__(self, master: tk.Misc, email_session: dict[str, str], origin: str):
+    def __init__(
+        self,
+        master: tk.Misc,
+        email_session: dict[str, str],
+        origin: str,
+        on_close: Callable[[], None] | None = None,
+    ):
         super().__init__(master, style="MyFrame.TFrame")
         self.master = master
         self.email_session = email_session
         self.origin = origin
+        self.on_close = on_close
         self.pasos: list[dict] = []
         self.flujos: list[dict] = []
         self.aliases: dict[str, str] = {}
@@ -517,8 +525,10 @@ class ActuaTareasScreen(ttk.Frame):
         self.aliases = {row[0].split("::", 1)[1]: row[1] for row in rows}
 
     def _go_back(self):
+        if callable(self.on_close):
+            self.on_close()
+            return
         from gestorcompras.ui import router
-
         router.open_home()
 
     def _refresh_inbox(self):
@@ -1230,6 +1240,39 @@ def abrir_panel_tareas(
     panel = ActuaExecutionPanel(master, email_session, origen, tareas or [], mode=mode)
     _OPEN_ACTUA_PANEL = panel
     return panel
+
+
+def open_actua_tareas_window(
+    master: tk.Misc,
+    email_session: dict[str, str],
+    origin: str = "bienes",
+) -> tk.Toplevel:
+    """Abre Actualizar Tareas como ventana independiente (consistente con otros módulos)."""
+    from gestorcompras.ui import router
+
+    win = tk.Toplevel(master)
+    win.title("Actualizar Tareas")
+    win.geometry("1120x760")
+    win.minsize(980, 620)
+    win.transient(master.winfo_toplevel() if hasattr(master, "winfo_toplevel") else master)
+
+    def _cerrar() -> None:
+        try:
+            win.grab_release()
+        except Exception:
+            pass
+        win.destroy()
+        try:
+            router.open_home()
+        except Exception:
+            logger.exception("No se pudo volver al menú al cerrar Actualizar Tareas.")
+
+    win.protocol("WM_DELETE_WINDOW", _cerrar)
+    screen = ActuaTareasScreen(win, email_session, origin=origin, on_close=_cerrar)
+    screen.pack(fill="both", expand=True)
+    win.grab_set()
+    win.focus_force()
+    return win
 
 
 def ejecutar_flujo_desde_modulo(

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -599,21 +599,33 @@ class ActuaTareasScreen(ttk.Frame):
                 return
 
         self.status_var.set("Ejecutando...")
+        pending_snapshot = [dict(p) for p in pending]
+        manual_snapshot = [dict(m) for m in manual_pending]
 
         def _worker():
             driver = None
             try:
-                if not pending:
-                    pending = manual_pending
-                if not pending:
+                pendientes = list(pending_snapshot)
+                if not pendientes:
+                    pendientes = list(manual_snapshot)
+                if not pendientes:
                     raise ValueError("Debe ingresar al menos una tarea manual o seleccionar tareas de bandeja.")
 
                 driver = _create_driver(headless=not self.mostrar_nav_var.get())
                 username, password = resolve_telcos_credentials(self.email_session)
-                login_telcos(driver, username, password)
+                ultimo_error = None
+                for _intento in range(1, 3):
+                    try:
+                        login_telcos(driver, username, password)
+                        ultimo_error = None
+                        break
+                    except Exception as exc:
+                        ultimo_error = exc
+                if ultimo_error is not None:
+                    raise ultimo_error
 
                 consumidas_ok: list[int] = []
-                for row in pending:
+                for row in pendientes:
                     ctx = {
                         "task_number": row.get("task_number"),
                         "numero_tarea": row.get("task_number"),

--- a/GestorCompras_/gestorcompras/ui/router.py
+++ b/GestorCompras_/gestorcompras/ui/router.py
@@ -132,6 +132,7 @@ def open_home() -> None:
 def open_actua_tareas(origin: str = "bienes") -> None:
     if _email_session is None:
         raise RuntimeError("Sesion de correo no inicializada")
-    _clear_container()
-    from gestorcompras.ui.actua_tareas_gui import ActuaTareasScreen
-    ActuaTareasScreen(_container, _email_session, origin=origin).pack(fill="both", expand=True)
+    open_home()
+    from gestorcompras.ui.actua_tareas_gui import open_actua_tareas_window
+
+    open_actua_tareas_window(_root(), _email_session, origin=origin)

--- a/GestorCompras_/gestorcompras/ui/router.py
+++ b/GestorCompras_/gestorcompras/ui/router.py
@@ -47,21 +47,25 @@ def open_module(module_id: str) -> None:
 
 
 def _open_bienes_reasignacion() -> None:
+    open_home()
     from gestorcompras.modules import reasignacion_gui
     reasignacion_gui.open(_root(), _email_session, mode="bienes")
 
 
 def _open_bienes_correos() -> None:
+    open_home()
     from gestorcompras.modules import correos_masivos_gui
     correos_masivos_gui.open(_root(), _email_session)
 
 
 def _open_bienes_seguimientos() -> None:
+    open_home()
     from gestorcompras.gui import seguimientos_gui
     seguimientos_gui.open_seguimientos(_root(), _email_session)
 
 
 def _open_bienes_descargas() -> None:
+    open_home()
     from gestorcompras.modules import descargas_oc_gui
     descargas_oc_gui.open(_root(), _email_session)
 
@@ -71,16 +75,19 @@ def _open_bienes_actua() -> None:
 
 
 def _open_servicios_reasignacion() -> None:
+    open_home()
     from gestorcompras.modules import reasignacion_gui
     reasignacion_gui.open(_root(), _email_session, mode="servicios")
 
 
 def _open_servicios_correos() -> None:
+    open_home()
     from gestorcompras.modules import correos_masivos_gui
     correos_masivos_gui.open(_root(), _email_session)
 
 
 def _open_servicios_descargas() -> None:
+    open_home()
     from gestorcompras.modules import descargas_oc_gui
     descargas_oc_gui.open(_root(), _email_session)
 
@@ -90,6 +97,7 @@ def _open_servicios_actua() -> None:
 
 
 def _open_config() -> None:
+    open_home()
     from gestorcompras.gui import config_gui
     config_gui.open_config_gui(_root(), _email_session)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jinja2~=3.1
 pdfplumber~=0.11
-pandas~=3.0
+pandas~=2.3
 openpyxl~=3.1
 selenium~=4.43
 webdriver-manager~=4.0


### PR DESCRIPTION
### Motivation
- Fix inconsistent PDF naming and case-insensitive filename conflicts when moving/renaming downloaded orders.
- Preserve backward compatibility for callers that expect the old `mover_oc` return shape while allowing callers to request file locations.
- Improve PDF name generation behavior and downstream renaming in selenium download flows.
- Add small GUI niceties and compatibility helpers to avoid regressions with legacy code paths.

### Description
- Make `_resolver_conflicto` in `mover_pdf` treat existing filenames case-insensitively by collecting `destino_dir` names lowercased to avoid name clashes on case-insensitive filesystems.
- Add `incluir_ubicaciones: bool = False` to `mover_oc` so it returns `(subidos, faltantes, errores)` by default for legacy callers and `(subidos, faltantes, errores, ubicaciones)` when requested, and adapt early-return behavior accordingly.
- Normalize conflict resolution and final returned paths consistently; adjust tests to consider case-insensitive `.pdf` suffixes.
- Revise `nombre_archivo_orden` in `pdf_info` to support a legacy format flag, normalize extensions to lower-case, and change provider-case handling to preserve legacy behavior when needed.
- Update selenium download/abastecimiento flows to produce more consistent downloaded filenames and to call `mover_oc(..., incluir_ubicaciones=True)` so callers receive file locations; adjust the renaming strategy to include a numeric prefix when available and produce normalized provider fragments.
- Add a compatibility wrapper `get_suppliers` and a fallback supplier lookup in `despacho_logic` to support older supplier table shapes.
- Improve `send_actua_report` to accept multiple common email/session keys and ensure the address is validated before sending.
- Enhance `actua_tareas_gui` with normalized task-number cleaning, retry on `login_telcos` attempts, a single-instance execution panel (`_OPEN_ACTUA_PANEL`), and "Regresar al menú" buttons to return to the main router.
- Make `router` open the home screen before launching many module panels to ensure consistent navigation state.
- Update `requirements.txt` to pin `pandas~=2.3` (compatibility adjustment).

### Testing
- Ran the modified download/move unit tests in `tests/test_mover_pdf.py` and they passed after updating expectations for case-insensitive `.pdf` suffix handling.
- Performed unit-level verification of `mover_oc` return shapes by invoking it with and without `incluir_ubicaciones` and confirmed both legacy and extended behaviors succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef89cfe4108320bb3a89b94d28dd93)