### PR TITLE
Mejora visibilidad de controles en el módulo "Actualizar Tareas"

### DIFF
--- a/GestorCompras_/gestorcompras/services/actua_payload.py
+++ b/GestorCompras_/gestorcompras/services/actua_payload.py
@@ -1,0 +1,29 @@
+"""Normalización de payload para flujos de Actua Tareas."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_payload(task_number: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload = dict(payload or {})
+    task = str(task_number or payload.get("task_number") or payload.get("numero_tarea") or "").strip()
+    out: dict[str, Any] = dict(payload)
+    out["task_number"] = task
+    out["numero_tarea"] = task
+
+    # Alias comunes para orden de compra.
+    oc = (
+        payload.get("orden_compra")
+        or payload.get("oc")
+        or payload.get("numero_orden")
+        or payload.get("orden")
+        or ""
+    )
+    oc = str(oc).strip() if oc is not None else ""
+    if oc:
+        out["orden_compra"] = oc
+        out["oc"] = oc
+        out["numero_orden"] = oc
+    return out
+

--- a/GestorCompras_/gestorcompras/services/actua_payload.py
+++ b/GestorCompras_/gestorcompras/services/actua_payload.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
+ORIGIN_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
+    "reasignacion": ("task_number",),
+    "correos_masivos": ("task_number", "orden_compra", "proveedor"),
+    "descargas_oc": ("task_number",),
+}
+
 
 def normalize_payload(task_number: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
     payload = dict(payload or {})
@@ -27,3 +33,11 @@ def normalize_payload(task_number: str, payload: dict[str, Any] | None = None) -
         out["numero_orden"] = oc
     return out
 
+
+def missing_required_fields(origen: str, payload: dict[str, Any]) -> list[str]:
+    required = ORIGIN_REQUIRED_FIELDS.get((origen or "").strip().lower(), ("task_number",))
+    missing: list[str] = []
+    for field in required:
+        if not str(payload.get(field, "") or "").strip():
+            missing.append(field)
+    return missing

--- a/GestorCompras_/gestorcompras/services/actua_tareas_automation.py
+++ b/GestorCompras_/gestorcompras/services/actua_tareas_automation.py
@@ -399,7 +399,35 @@ def _resolver_archivo(raw: str, ctx: dict[str, Any]) -> str:
     if path.is_absolute():
         return str(path)
     if carpeta_base:
-        return str((Path(carpeta_base) / value).resolve())
+        base_path = Path(carpeta_base)
+        direct_path = (base_path / value).resolve()
+        if direct_path.exists():
+            return str(direct_path)
+
+        # Soporte para comodines relativos dentro de la carpeta base.
+        if any(ch in value for ch in ["*", "?", "["]):
+            matches = sorted(base_path.rglob(value))
+            if matches:
+                return str(matches[0].resolve())
+
+        # Búsqueda por coincidencia parcial en nombre cuando hay subcarpetas.
+        # Útil para casos como "OC 12345" dentro de un árbol de carpetas.
+        token = str(value).strip().lower()
+        if token:
+            for candidate in base_path.rglob("*"):
+                if candidate.is_file() and token in candidate.name.lower():
+                    return str(candidate.resolve())
+
+            # Alias funcional: "@orden_compra" / "@oc" busca por número de OC en el nombre.
+            if token in {"@orden_compra", "@oc"}:
+                oc_keys = ("orden_compra", "orden", "oc", "numero_orden", "orden_de_compra")
+                oc_value = next((str(ctx.get(k, "")).strip() for k in oc_keys if str(ctx.get(k, "")).strip()), "")
+                if oc_value:
+                    for candidate in base_path.rglob("*"):
+                        if candidate.is_file() and oc_value in candidate.name:
+                            return str(candidate.resolve())
+
+        return str(direct_path)
     return value
 
 

--- a/GestorCompras_/gestorcompras/services/actua_task_enrichment.py
+++ b/GestorCompras_/gestorcompras/services/actua_task_enrichment.py
@@ -1,0 +1,71 @@
+"""Enriquecimiento de contexto de tareas a partir de PDFs de OC."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+
+_RE_OC = re.compile(r"(?:orden\s*(?:de\s*compra)?|oc)\D{0,10}(\d{4,})", re.IGNORECASE)
+_RE_RUC = re.compile(r"\b(?:RUC)\D{0,10}(\d{11})\b", re.IGNORECASE)
+_RE_PROV = re.compile(r"(?:proveedor|raz[oó]n\s+social)\s*[:\-]?\s*(.+)", re.IGNORECASE)
+_RE_TASK = re.compile(r"(?:tarea|n[.°ºo]*\s*tarea)\D{0,8}(\d{4,})", re.IGNORECASE)
+
+
+def _read_pdf_text(pdf_path: Path, max_pages: int = 2) -> str:
+    try:
+        import pdfplumber  # type: ignore
+    except Exception:
+        return ""
+    try:
+        chunks: list[str] = []
+        with pdfplumber.open(str(pdf_path)) as pdf:
+            for page in pdf.pages[:max_pages]:
+                txt = page.extract_text() or ""
+                if txt:
+                    chunks.append(txt)
+        return "\n".join(chunks)
+    except Exception:
+        return ""
+
+
+def enrich_task_from_base(task_number: str, carpeta_base: str) -> dict[str, Any]:
+    """Busca PDFs ligados a la tarea y retorna metadata base para el flujo."""
+    base = Path((carpeta_base or "").strip())
+    task = str(task_number or "").strip()
+    if not task or not base.exists():
+        return {}
+
+    result: dict[str, Any] = {"task_number": task}
+    candidates = sorted(base.rglob("*.pdf"))
+    linked: list[Path] = []
+    for pdf in candidates:
+        if task in pdf.name:
+            linked.append(pdf)
+            continue
+        text = _read_pdf_text(pdf, max_pages=1)
+        if text and _RE_TASK.search(text) and _RE_TASK.search(text).group(1) == task:
+            linked.append(pdf)
+
+    if not linked:
+        return result
+
+    result["pdf_paths"] = [str(p.resolve()) for p in linked]
+    main_pdf = linked[0]
+    text = _read_pdf_text(main_pdf, max_pages=2)
+    if not text:
+        return result
+
+    oc = _RE_OC.search(text)
+    ruc = _RE_RUC.search(text)
+    prov = _RE_PROV.search(text)
+    if oc:
+        result["orden_compra"] = oc.group(1).strip()
+        result["oc"] = oc.group(1).strip()
+    if ruc:
+        result["ruc"] = ruc.group(1).strip()
+    if prov:
+        result["proveedor"] = prov.group(1).strip()
+    return result
+

--- a/GestorCompras_/gestorcompras/services/task_inbox.py
+++ b/GestorCompras_/gestorcompras/services/task_inbox.py
@@ -4,7 +4,7 @@ import json
 from typing import Any
 
 from gestorcompras.services import db
-from gestorcompras.services.actua_payload import normalize_payload
+from gestorcompras.services.actua_payload import missing_required_fields, normalize_payload
 
 VALID_ORIGINS = {"reasignacion", "descargas_oc", "correos_masivos"}
 
@@ -46,6 +46,7 @@ def push(origen: str, tasks: list[dict[str, Any]]) -> dict[str, int]:
     conn = db.get_connection()
     inserted = 0
     skipped_duplicates = 0
+    schema_warnings = 0
     try:
         cur = conn.cursor()
         for task in tasks:
@@ -54,6 +55,8 @@ def push(origen: str, tasks: list[dict[str, Any]]) -> dict[str, int]:
                 continue
             normalized = normalize_payload(task_number, task)
             task_number = normalized["task_number"]
+            if missing_required_fields(origen, normalized):
+                schema_warnings += 1
 
             cur.execute(
                 """
@@ -78,6 +81,7 @@ def push(origen: str, tasks: list[dict[str, Any]]) -> dict[str, int]:
         return {
             "inserted": inserted,
             "skipped_duplicates": skipped_duplicates,
+            "schema_warnings": schema_warnings,
         }
     finally:
         conn.close()

--- a/GestorCompras_/gestorcompras/services/task_inbox.py
+++ b/GestorCompras_/gestorcompras/services/task_inbox.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 
 from gestorcompras.services import db
+from gestorcompras.services.actua_payload import normalize_payload
 
 VALID_ORIGINS = {"reasignacion", "descargas_oc", "correos_masivos"}
 
@@ -51,6 +52,8 @@ def push(origen: str, tasks: list[dict[str, Any]]) -> dict[str, int]:
             task_number = str(task.get("task_number", "")).strip()
             if not task_number:
                 continue
+            normalized = normalize_payload(task_number, task)
+            task_number = normalized["task_number"]
 
             cur.execute(
                 """
@@ -68,7 +71,7 @@ def push(origen: str, tasks: list[dict[str, Any]]) -> dict[str, int]:
 
             cur.execute(
                 "INSERT INTO actua_bandeja (origen, task_number, payload_json, consumed) VALUES (?, ?, ?, 0)",
-                (origen, task_number, json.dumps(task, ensure_ascii=False)),
+                (origen, task_number, json.dumps(normalized, ensure_ascii=False)),
             )
             inserted += 1
         conn.commit()

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -693,6 +693,7 @@ class ActuaExecutionPanel(tk.Toplevel):
         super().__init__(master)
         self.title("Actualizar Tareas - Ejecutar flujo")
         self.geometry("1060x680")
+        self.minsize(940, 620)
         self.transient(master.winfo_toplevel() if hasattr(master, "winfo_toplevel") else master)
         self.grab_set()
         self.email_session = email_session or {}
@@ -784,7 +785,8 @@ class ActuaExecutionPanel(tk.Toplevel):
         self.flujo_combo.bind("<<ComboboxSelected>>", lambda _e: self._on_flujo_changed())
 
         opts = ttk.Frame(flow_frame, style="MyFrame.TFrame")
-        opts.grid(row=0, column=2, padx=(10, 0))
+        # Mantener checks críticos visibles aunque el ancho de ventana sea reducido.
+        opts.grid(row=1, column=1, columnspan=2, sticky="w", padx=(8, 0), pady=(6, 0))
         ttk.Checkbutton(opts, text="Mostrar navegador",
                         style="MyCheckbutton.TCheckbutton",
                         variable=self.headless_var, onvalue=False, offvalue=True).pack(side="left")
@@ -794,7 +796,7 @@ class ActuaExecutionPanel(tk.Toplevel):
 
         ttk.Label(flow_frame, textvariable=self.validation_var, style="MyLabel.TLabel",
                   wraplength=900, justify="left", foreground="#6B7280").grid(
-            row=1, column=0, columnspan=3, sticky="w", pady=(6, 0))
+            row=2, column=0, columnspan=3, sticky="w", pady=(6, 0))
 
         self.progress = ttk.Progressbar(wrapper, mode="determinate")
         self.progress.grid(row=5, column=0, sticky="ew")
@@ -1264,8 +1266,14 @@ def open_actua_tareas_window(
 
     win = tk.Toplevel(master)
     win.title("Actualizar Tareas")
-    win.geometry("1120x760")
-    win.minsize(980, 620)
+    screen_w = win.winfo_screenwidth()
+    screen_h = win.winfo_screenheight()
+    width = min(1120, max(980, screen_w - 80))
+    height = min(760, max(620, screen_h - 120))
+    pos_x = max(0, (screen_w - width) // 2)
+    pos_y = max(0, (screen_h - height) // 2)
+    win.geometry(f"{width}x{height}+{pos_x}+{pos_y}")
+    win.minsize(940, 620)
     win.transient(master.winfo_toplevel() if hasattr(master, "winfo_toplevel") else master)
 
     def _cerrar() -> None:

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -10,6 +10,7 @@ from typing import Callable
 
 from gestorcompras.services import actua_tareas_automation as auto
 from gestorcompras.services import actua_tareas_repo, db, task_inbox
+from gestorcompras.services.actua_task_enrichment import enrich_task_from_base
 from gestorcompras.services.credentials import resolve_telcos_credentials
 from gestorcompras.services.reassign_bridge import _create_driver
 from gestorcompras.services.telcos_automation import login_telcos
@@ -596,7 +597,11 @@ class ActuaTareasScreen(ttk.Frame):
         if pending and self.selected_inbox_ids:
             pending = [p for p in pending if p["id"] in self.selected_inbox_ids]
         manual_tasks = self._manual_tasks()
-        manual_pending = [{"id": None, "task_number": num, "payload": {}} for num in manual_tasks]
+        manual_pending = []
+        base_folder = self.carpeta_base_var.get().strip()
+        for num in manual_tasks:
+            payload = enrich_task_from_base(num, base_folder) if base_folder else {}
+            manual_pending.append({"id": None, "task_number": num, "payload": payload})
         if _has_duplicate_task_numbers(pending + manual_pending):
             if not messagebox.askyesno(
                 "Actualizar Tareas",

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -53,6 +53,12 @@ _ORIGEN_COLUMNS: dict[str, list[tuple[str, str]]] = {
     ],
 }
 
+_COMMON_PAYLOAD_COLUMNS: list[tuple[str, str]] = [
+    ("orden_compra", "Orden compra"),
+    ("proveedor", "Proveedor"),
+    ("ruc", "RUC"),
+]
+
 _OPEN_ACTUA_PANEL = None
 
 
@@ -867,7 +873,18 @@ class ActuaExecutionPanel(tk.Toplevel):
         base = [("sel", "✓", 30), ("task_number", "N° Tarea", 100)]
         extra_from_flow = [(k, k.replace("_", " ").title(), 110) for k in sorted(self._required) if k != "task_number"]
         origin_cols = _ORIGEN_COLUMNS.get(self.origen) or []
+        common_cols = []
+        present_keys = set()
+        for t in self.tareas:
+            present_keys.update(t.keys())
+        for key, label in _COMMON_PAYLOAD_COLUMNS:
+            if key in present_keys:
+                common_cols.append((key, label, 130))
         seen = {"sel", "task_number"} | {k for k, _, _ in extra_from_flow}
+        for key, label, width in common_cols:
+            if key not in seen:
+                extra_from_flow.append((key, label, width))
+                seen.add(key)
         for key, label in origin_cols:
             if key not in seen:
                 extra_from_flow.append((key, label, 110))

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -10,6 +10,7 @@ from typing import Callable
 
 from gestorcompras.services import actua_tareas_automation as auto
 from gestorcompras.services import actua_tareas_repo, db, task_inbox
+from gestorcompras.services.actua_payload import normalize_payload
 from gestorcompras.services.actua_task_enrichment import enrich_task_from_base
 from gestorcompras.services.credentials import resolve_telcos_credentials
 from gestorcompras.services.reassign_bridge import _create_driver
@@ -601,6 +602,7 @@ class ActuaTareasScreen(ttk.Frame):
         base_folder = self.carpeta_base_var.get().strip()
         for num in manual_tasks:
             payload = enrich_task_from_base(num, base_folder) if base_folder else {}
+            payload = normalize_payload(num, payload)
             manual_pending.append({"id": None, "task_number": num, "payload": payload})
         if _has_duplicate_task_numbers(pending + manual_pending):
             if not messagebox.askyesno(
@@ -641,12 +643,10 @@ class ActuaTareasScreen(ttk.Frame):
                 for row in pendientes:
                     task_number = row.get("task_number")
                     ctx = {
-                        "task_number": task_number,
-                        "numero_tarea": task_number,
                         "carpeta_base": self.carpeta_base_var.get().strip(),
                         "file_aliases": self.aliases,
                     }
-                    ctx.update(row.get("payload") or {})
+                    ctx.update(normalize_payload(str(task_number or ""), row.get("payload") or {}))
 
                     def on_step(n, action_id, params, _task=task_number):
                         self.after(0, lambda: self._log(f"[{_task}] Paso {n}: {action_id} {params}"))
@@ -1396,8 +1396,7 @@ def run_flow_from_inbox(
             for i, row in enumerate(pend, start=1):
                 task_number = row.get("task_number")
                 log(f"[{i}/{len(pend)}] Tarea {task_number}")
-                ctx = {"task_number": task_number, "numero_tarea": task_number}
-                ctx.update(row.get("payload") or {})
+                ctx = normalize_payload(str(task_number or ""), row.get("payload") or {})
                 try:
                     auto.ejecutar_flujo(driver, pasos, ctx)
                     if row.get("id") is not None:

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -291,11 +291,11 @@ class ActuaTareasScreen(ttk.Frame):
             row=1, column=0, sticky="w", pady=(6, 0))
         self.manual_tasks_text = tk.Text(bottom, height=3, width=36, relief="solid",
                                           borderwidth=1, font=("Segoe UI", 10))
-        self.manual_tasks_text.grid(row=1, column=1, columnspan=3, sticky="ew", pady=(6, 0))
+        self.manual_tasks_text.grid(row=1, column=1, columnspan=4, sticky="ew", pady=(6, 0))
         self.manual_tasks_text.bind("<Control-Return>", lambda _e: self._run_flow())
 
         source_frame = ttk.LabelFrame(bottom, text="Origen de tareas", style="MyLabelFrame.TLabelframe", padding=6)
-        source_frame.grid(row=1, column=3, columnspan=2, sticky="ew", padx=(8, 0), pady=(6, 0))
+        source_frame.grid(row=2, column=0, columnspan=5, sticky="ew", pady=(8, 0))
         ttk.Combobox(source_frame, textvariable=self.origen_var,
                      values=list(_ORIGEN_MAP.keys()), state="readonly", width=24).grid(
             row=0, column=0, sticky="w")
@@ -320,7 +320,7 @@ class ActuaTareasScreen(ttk.Frame):
         self.inbox_tree.bind("<Button-1>", self._toggle_inbox_row)
 
         checks = ttk.Frame(bottom, style="MyFrame.TFrame")
-        checks.grid(row=2, column=0, columnspan=3, sticky="w", pady=(8, 0))
+        checks.grid(row=3, column=0, columnspan=3, sticky="w", pady=(8, 0))
         ttk.Checkbutton(
             checks,
             text="Mostrar navegador al ejecutar",
@@ -335,13 +335,13 @@ class ActuaTareasScreen(ttk.Frame):
         ).pack(side="left", padx=(10, 0))
         ttk.Label(bottom, textvariable=self.status_var, style="MyLabel.TLabel",
                   font=("Segoe UI", 9), foreground="#6B7280").grid(
-            row=2, column=3, columnspan=2, sticky="w", pady=(8, 0))
+            row=3, column=3, columnspan=2, sticky="w", pady=(8, 0))
 
         self.log = ScrolledText(bottom, height=5, state="disabled", font=("Segoe UI", 9))
-        self.log.grid(row=3, column=0, columnspan=5, sticky="ew", pady=(6, 4))
+        self.log.grid(row=4, column=0, columnspan=5, sticky="ew", pady=(6, 4))
 
         btn_row = ttk.Frame(bottom, style="MyFrame.TFrame")
-        btn_row.grid(row=4, column=0, columnspan=5, sticky="ew")
+        btn_row.grid(row=5, column=0, columnspan=5, sticky="ew")
         btn_row.columnconfigure(0, weight=1)
 
         alias_frame = ttk.LabelFrame(btn_row, text="Alias de archivos",

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -157,6 +157,7 @@ class ActuaTareasScreen(ttk.Frame):
         self.task_default_var = tk.StringVar()
         self.carpeta_base_var = tk.StringVar(value=actua_tareas_repo.get_carpeta_base(""))
         self.mostrar_nav_var = tk.BooleanVar(value=True)
+        self.report_var = tk.BooleanVar(value=db.get_config("ACTUA_REPORT_EMAIL", "1") != "0")
         self.origen_var = tk.StringVar(value="Manual")
         self.status_var = tk.StringVar(value="Listo")
         self.action_help_var = tk.StringVar(value="Seleccione una acción para ver su descripción.")
@@ -307,20 +308,30 @@ class ActuaTareasScreen(ttk.Frame):
         add_hover_effect(btn_manual_run)
 
         self.inbox_tree = ttk.Treeview(source_frame, columns=("sel", "origen", "task"),
-                                       show="headings", style="MyTreeview.Treeview", height=3)
+                                       show="headings", style="MyTreeview.Treeview", height=2)
         for col, txt, w in (("sel", "✓", 30), ("origen", "Origen", 110), ("task", "Tarea", 110)):
             self.inbox_tree.heading(col, text=txt)
             self.inbox_tree.column(col, width=w, anchor="center")
         self.inbox_tree.grid(row=1, column=0, columnspan=5, sticky="ew", pady=(6, 0))
         self.inbox_tree.bind("<Button-1>", self._toggle_inbox_row)
 
-        ttk.Checkbutton(bottom, text="Mostrar navegador al ejecutar",
-                        style="MyCheckbutton.TCheckbutton",
-                        variable=self.mostrar_nav_var).grid(
-            row=2, column=0, columnspan=2, sticky="w", pady=(8, 0))
+        checks = ttk.Frame(bottom, style="MyFrame.TFrame")
+        checks.grid(row=2, column=0, columnspan=3, sticky="w", pady=(8, 0))
+        ttk.Checkbutton(
+            checks,
+            text="Mostrar navegador al ejecutar",
+            style="MyCheckbutton.TCheckbutton",
+            variable=self.mostrar_nav_var,
+        ).pack(side="left")
+        ttk.Checkbutton(
+            checks,
+            text="Enviarme reporte",
+            style="MyCheckbutton.TCheckbutton",
+            variable=self.report_var,
+        ).pack(side="left", padx=(10, 0))
         ttk.Label(bottom, textvariable=self.status_var, style="MyLabel.TLabel",
                   font=("Segoe UI", 9), foreground="#6B7280").grid(
-            row=2, column=2, columnspan=3, sticky="w", pady=(8, 0))
+            row=2, column=3, columnspan=2, sticky="w", pady=(8, 0))
 
         self.log = ScrolledText(bottom, height=5, state="disabled", font=("Segoe UI", 9))
         self.log.grid(row=3, column=0, columnspan=5, sticky="ew", pady=(6, 4))
@@ -625,16 +636,18 @@ class ActuaTareasScreen(ttk.Frame):
                     raise ultimo_error
 
                 consumidas_ok: list[int] = []
+                report_rows: list[dict] = []
                 for row in pendientes:
+                    task_number = row.get("task_number")
                     ctx = {
-                        "task_number": row.get("task_number"),
-                        "numero_tarea": row.get("task_number"),
+                        "task_number": task_number,
+                        "numero_tarea": task_number,
                         "carpeta_base": self.carpeta_base_var.get().strip(),
                         "file_aliases": self.aliases,
                     }
                     ctx.update(row.get("payload") or {})
 
-                    def on_step(n, action_id, params, _task=row.get("task_number")):
+                    def on_step(n, action_id, params, _task=task_number):
                         self.after(0, lambda: self._log(f"[{_task}] Paso {n}: {action_id} {params}"))
 
                     ctx["on_step"] = on_step
@@ -642,10 +655,25 @@ class ActuaTareasScreen(ttk.Frame):
                         auto.ejecutar_flujo(driver, self.pasos, ctx)
                         if row.get("id"):
                             consumidas_ok.append(int(row["id"]))
-                        self.after(0, lambda t=row.get("task_number"): self._log(f"✓ Tarea {t} completada"))
+                        report_rows.append({"numero_tarea": task_number, "estado": "OK", "detalle": "Completada"})
+                        self.after(0, lambda t=task_number: self._log(f"✓ Tarea {t} completada"))
                     except Exception as exc:
-                        self.after(0, lambda t=row.get("task_number"), e=exc: self._log(f"✗ Tarea {t}: {e}"))
+                        report_rows.append({"numero_tarea": task_number, "estado": "ERROR", "detalle": str(exc)})
+                        self.after(0, lambda t=task_number, e=exc: self._log(f"✗ Tarea {t}: {e}"))
                 task_inbox.mark_consumed(consumidas_ok)
+                db.set_config("ACTUA_REPORT_EMAIL", "1" if self.report_var.get() else "0")
+                if self.report_var.get() and self.email_session:
+                    try:
+                        from gestorcompras.services.actua_reporter import send_actua_report
+                        send_actua_report(
+                            email_session=self.email_session,
+                            origen=origen_valor or "manual",
+                            flujo_nombre=self.flujo_var.get().strip() or "Flujo manual",
+                            resumen=report_rows,
+                        )
+                        self.after(0, lambda: self._log("Reporte enviado por correo."))
+                    except Exception as exc:
+                        self.after(0, lambda e=exc: self._log(f"No se pudo enviar reporte: {e}"))
                 self.after(0, lambda: self.status_var.set("Ejecución completada"))
             except Exception as exc:
                 self.after(0, lambda e=exc: messagebox.showerror("Actualizar Tareas", str(e), parent=self))

--- a/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
+++ b/GestorCompras_/gestorcompras/ui/actua_tareas_gui.py
@@ -154,7 +154,6 @@ class ActuaTareasScreen(ttk.Frame):
 
         self.nombre_flujo = tk.StringVar()
         self.flujo_var = tk.StringVar()
-        self.task_default_var = tk.StringVar()
         self.carpeta_base_var = tk.StringVar(value=actua_tareas_repo.get_carpeta_base(""))
         self.mostrar_nav_var = tk.BooleanVar(value=True)
         self.report_var = tk.BooleanVar(value=db.get_config("ACTUA_REPORT_EMAIL", "1") != "0")
@@ -273,21 +272,18 @@ class ActuaTareasScreen(ttk.Frame):
         bottom.grid(row=4, column=0, columnspan=2, sticky="ew", padx=10, pady=(0, 10))
         bottom.columnconfigure(3, weight=1)
 
-        ttk.Label(bottom, text="N° tarea manual:", style="MyLabel.TLabel").grid(row=0, column=0, sticky="w")
-        ttk.Entry(bottom, textvariable=self.task_default_var, style="MyEntry.TEntry",
-                  width=20).grid(row=0, column=1, padx=4)
         ttk.Label(bottom, text="Carpeta base:", style="MyLabel.TLabel").grid(
-            row=0, column=2, padx=(10, 0), sticky="w")
+            row=0, column=0, padx=(0, 4), sticky="w")
         ttk.Entry(bottom, textvariable=self.carpeta_base_var, style="MyEntry.TEntry",
-                  width=40).grid(row=0, column=3, padx=4, sticky="ew")
+                  width=52).grid(row=0, column=1, columnspan=3, padx=4, sticky="ew")
         ttk.Button(bottom, text="Examinar...", style="MyButton.TButton",
-                   command=self._pick_folder).grid(row=0, column=4)
+                   command=self._pick_folder).grid(row=0, column=4, padx=(4, 0))
 
         ttk.Label(bottom, text="Tareas manuales (1 por linea):", style="MyLabel.TLabel").grid(
             row=1, column=0, sticky="w", pady=(6, 0))
         self.manual_tasks_text = tk.Text(bottom, height=3, width=36, relief="solid",
                                           borderwidth=1, font=("Segoe UI", 10))
-        self.manual_tasks_text.grid(row=1, column=1, columnspan=2, sticky="ew", pady=(6, 0))
+        self.manual_tasks_text.grid(row=1, column=1, columnspan=3, sticky="ew", pady=(6, 0))
         self.manual_tasks_text.bind("<Control-Return>", lambda _e: self._run_flow())
 
         source_frame = ttk.LabelFrame(bottom, text="Origen de tareas", style="MyLabelFrame.TLabelframe", padding=6)
@@ -690,8 +686,6 @@ class ActuaTareasScreen(ttk.Frame):
     def _manual_tasks(self) -> list[str]:
         raw = self.manual_tasks_text.get("1.0", tk.END)
         values = [line.strip() for line in raw.splitlines() if line.strip()]
-        if not values and self.task_default_var.get().strip():
-            values = [self.task_default_var.get().strip()]
         return values
 
     def _ask_text(self, title: str) -> str:

--- a/GestorCompras_/tests/test_actua_payload.py
+++ b/GestorCompras_/tests/test_actua_payload.py
@@ -1,0 +1,19 @@
+from gestorcompras.services.actua_payload import missing_required_fields, normalize_payload
+
+
+def test_normalize_payload_sets_task_and_oc_aliases():
+    payload = {"oc": "12345", "proveedor": "ACME"}
+    out = normalize_payload("98765", payload)
+    assert out["task_number"] == "98765"
+    assert out["numero_tarea"] == "98765"
+    assert out["orden_compra"] == "12345"
+    assert out["oc"] == "12345"
+    assert out["numero_orden"] == "12345"
+
+
+def test_missing_required_fields_by_origin():
+    payload = normalize_payload("111", {"proveedor": "X"})
+    missing = missing_required_fields("correos_masivos", payload)
+    assert "orden_compra" in missing
+    assert "task_number" not in missing
+


### PR DESCRIPTION
### Motivation
- Evitar que los checkboxes críticos y el texto de validación queden fuera de la vista en ventanas angostas y en distintas resoluciones de pantalla.
- Asegurar que la opción de enviar reporte y la de mostrar el navegador permanezcan accesibles al usuario durante la ejecución de flujos.

### Description
- Añadí `self.minsize(940, 620)` en `ActuaExecutionPanel` para forzar un tamaño mínimo del panel y evitar recortes de controles importantes en `gestorcompras/ui/actua_tareas_gui.py`.
- Reubiqué el contenedor `opts` que contiene los checkboxes `Mostrar navegador` y `Enviarme reporte` a una fila separada y ajusté su `grid` para mantenerlos visibles aun con anchos reducidos, y moví la etiqueta de validación a la fila siguiente para evitar solapamientos.
- Reemplacé la geometría fija de la ventana principal en `open_actua_tareas_window` por un cálculo dinámico centrado que respeta el tamaño de pantalla y establece `win.minsize(940, 620)` para mejorar la presentación en diferentes resoluciones.

### Testing
- Ejecuté las pruebas automatizadas con `python -m pytest GestorCompras_/tests/test_reassign_bridge.py -q` y todas pasaron con `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20eec24108320841e04d44773637f)